### PR TITLE
Fixed links and anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,415 +2,409 @@
 
 - [Awesome Geospatial](#awesome-geospatial)
     - [Database](#database)
-    - [Image Classification & DIP Software ] (#image-classification-&-DIP-software)
-    - [Geographic Information System] (#geographic-information-system)
-    - [Web Map Development] (#web-map-development)
-    - [Web Map Server] (#web-map-server)
-    - [Radar] (#radar)
-    - [Lidar] (#lidar)
-    - [Geographic Data Mining] (#geographic-data-mining)
-    - [Atmospheric Correction] (#atmospheric-correction)
-    - [Libraries] (#libraries)
-    - [Python] (#python)
-    - [PaaS - Platform as a Service] (#platform-as-a-service)
-    - [SaaS – Software as a Service] (#software-as-a-service)
-    - [DaaS – Data as a Service] (#data-as-a-service)
-    - [Java] (#java)
-    - [C Sharp] (#c-sharp)
-    - [C++] (#c++)
-    - [C] (#c)
-    - [Ruby] (#ruby)
-    - [CSS] (#css)
-    - [Julia] (#julia)
-    - [R] (#r)
-    - [JavaScript] (#javascript)
-    - [Node.js] (#node.js)
-    - [Mobile Development] (#mobile-development)
-    - [Visualization] (#visualization)
-    - [Tools] (#tools)
-    - [Data Sources] (#data-sources)
-    - [Resources] (#resources)
-    - [References] (#references)
+    - [Image Classification & DIP Software](#image-classification--dip-software)
+    - [Geographic Information System](#geographic-information-system)
+    - [Web Map Development](#web-map-development)
+    - [Web Map Server](#web-map-server)
+    - [Radar](#radar)
+    - [Lidar](#lidar)
+    - [Geographic Data Mining](#geographic-data-mining)
+    - [Atmospheric Correction](#atmospheric-correction)
+    - [Libraries](#libraries)
+    - [Python](#python)
+    - [PaaS - Platform as a Service](#paas---platform-as-a-service)
+    - [SaaS - Software as a Service](#saas---software-as-a-service)
+    - [DaaS - Data as a Service](#daas---data-as-a-service)
+    - [Java](#java)
+    - [C Sharp](#c-sharp)
+    - [C++](#c++)
+    - [C](#c)
+    - [Ruby](#ruby)
+    - [CSS](#css)
+    - [Julia](#julia)
+    - [R](#r)
+    - [JavaScript](#javascript)
+    - [Node.js](#nodejs)
+    - [Mobile Development](#mobile-development)
+    - [Visualization](#visualization)
+    - [Tools](#tools)
+    - [Data Sources](#data-sources)
+    - [Resources](#resources)
+    - [References](#references)
 
 - - -
 
 ## Database
 
 * [PostGIS](http://postgis.net/) - PostgreSql spatial extension.
-* [PostGIS Vector Tile Utils] (https://github.com/mapbox/postgis-vt-util) - A set of PostgreSQL functions that are useful when creating vector tile sources.
+* [PostGIS Vector Tile Utils](https://github.com/mapbox/postgis-vt-util) - A set of PostgreSQL functions that are useful when creating vector tile sources.
 * [Spatialite](http://www.gaia-gis.it/gaia-sins/) - SQLite spatial extension.
 * [Neo4j Spatial](https://github.com/neo4j-contrib/spatial) - Library of spatial utilities for Neo4j.
 * [Oracle Spatial](http://www.oracle.com/us/products/database/options/spatial/overview/index.html) - Oracle database spatial extension.
 * [MySql Spatial](http://dev.mysql.com/doc/refman/5.7/en/spatial-extensions.html) - MySql spatial extension.
-* [GeoCouch] (https://github.com/couchbase/geocouch) - GeoCouch is a spatial extension for Couchbase and Apache CouchDB.
-* [Cloudant] (https://cloudant.com/) - IBM noSQL database that supports spatial data (GeoJSON).
-* [MondoDB] (https://www.mongodb.com/) - Also supports GeoJSON and spatial indexes.
-* [DB2 Spatial Extender] (http://www-03.ibm.com/software/products/en/db2spaext) - Spatial Extender allows you to store, manage, and analyze spatial data in DB2.
-* [Informix Spatial] (http://www-01.ibm.com/software/data/informix/spatial/) - Informix spatial extension.
-* [Teradata Geospatial Feature] (http://br.teradata.com/Resources/Demos/Teradata-Geospatial-Features-Overview/?LangType=1046&LangSelect=true) - Teradata spatial extension for DW and BI.
+* [GeoCouch](https://github.com/couchbase/geocouch) - GeoCouch is a spatial extension for Couchbase and Apache CouchDB.
+* [Cloudant](https://cloudant.com/) - IBM noSQL database that supports spatial data (GeoJSON).
+* [MondoDB](https://www.mongodb.com/) - Also supports GeoJSON and spatial indexes.
+* [DB2 Spatial Extender](http://www-03.ibm.com/software/products/en/db2spaext) - Spatial Extender allows you to store, manage, and analyze spatial data in DB2.
+* [Informix Spatial](http://www-01.ibm.com/software/data/informix/spatial/) - Informix spatial extension.
+* [Teradata Geospatial Feature](http://br.teradata.com/Resources/Demos/Teradata-Geospatial-Features-Overview/?LangType=1046&LangSelect=true) - Teradata spatial extension for DW and BI.
 
 
 ## Image Classification & DIP Software
 
-* [eCognition] (http://www.ecognition.com/suite/ecognition-developer) - GEOBIA software.
-* [Interimage] (http://www.lvc.ele.puc-rio.br/projects/interimage/) - Open Source GEOBIA software.
-* [ENVI] (http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/ENVI.aspx) - Geospatial image processing and classification software.
-* [ERDAS] (http://www.hexagongeospatial.com/products/producer-suite/erdas-imagine) - Geospatial image processing and classification software.
-* [PCI Geomatica] (http://www.pcigeomatics.com/software/geomatica/professional) - Remote sensing software package for image processing
-* [Global Mapper] (http://www.bluemarblegeo.com/products/global-mapper.php) - Geospatial and remote sensing data analysis.
-* [Spring] (http://www.dpi.inpe.br/spring/english/index.html) - GIS and remote sensing image processing system with an object-oriented data model.
-* [TerrSet] (https://clarklabs.org/terrset/) - TerrSet (formerly IDRISI) is an integrated geographic information system (GIS) and remote sensing software
-* [OSSIM] (http://trac.osgeo.org/ossim/) - Suite of geospatial libraries and applications used to process imagery, maps, terrain, and vector data.
-* [e-Foto] (http://www.efoto.eng.uerj.br/en) - Free and open source digital photogrammetric workstation.
-* [Guidos Toolbox] (http://forest.jrc.ec.europa.eu/download/software/guidos/) - Some GDAL functionalities and includes MSPA (Morphological Spatial Pattern Analysis) for connectivity maps.
-* [Matlab] (http://www.mathworks.com/products/matlab/) - Multi-paradigm numerical computing environment and fourth-generation programming language.
-* [IDL] (http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/IDL.aspx) - IDL is a programming language used for data analysis and image processing programming.
-* [ArcMap Raster Edit Suite] (https://github.com/haoliangyu/ares) - An ArcMap Addin that enables manual editing of single pixels on raster layer.
+* [eCognition](http://www.ecognition.com/suite/ecognition-developer) - GEOBIA software.
+* [Interimage](http://www.lvc.ele.puc-rio.br/projects/interimage/) - Open Source GEOBIA software.
+* [ENVI](http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/ENVI.aspx) - Geospatial image processing and classification software.
+* [ERDAS](http://www.hexagongeospatial.com/products/producer-suite/erdas-imagine) - Geospatial image processing and classification software.
+* [PCI Geomatica](http://www.pcigeomatics.com/software/geomatica/professional) - Remote sensing software package for image processing
+* [Global Mapper](http://www.bluemarblegeo.com/products/global-mapper.php) - Geospatial and remote sensing data analysis.
+* [Spring](http://www.dpi.inpe.br/spring/english/index.html) - GIS and remote sensing image processing system with an object-oriented data model.
+* [TerrSet](https://clarklabs.org/terrset/) - TerrSet (formerly IDRISI) is an integrated geographic information system (GIS) and remote sensing software
+* [OSSIM](http://trac.osgeo.org/ossim/) - Suite of geospatial libraries and applications used to process imagery, maps, terrain, and vector data.
+* [e-Foto](http://www.efoto.eng.uerj.br/en) - Free and open source digital photogrammetric workstation.
+* [Guidos Toolbox](http://forest.jrc.ec.europa.eu/download/software/guidos/) - Some GDAL functionalities and includes MSPA (Morphological Spatial Pattern Analysis) for connectivity maps.
+* [Matlab](http://www.mathworks.com/products/matlab/) - Multi-paradigm numerical computing environment and fourth-generation programming language.
+* [IDL](http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/IDL.aspx) - IDL is a programming language used for data analysis and image processing programming.
+* [ArcMap Raster Edit Suite](https://github.com/haoliangyu/ares) - An ArcMap Addin that enables manual editing of single pixels on raster layer.
 
 
 ## Geographic Information System
 
-* [ArcGIS] (https://www.arcgis.com/features/) - GIS for working with maps and geographic information.
-* [QGIS] (http://www.qgis.org/en/site/) - Cross-platform free and open-source desktop geographic information system.
-* [Terraview] (http://www.dpi.inpe.br/terraview_eng/index.php) - GIS application built using the TerraLib  GIS library.
-* [gvSIG] (http://www.gvsig.com/en) - Free and open source GIS.
-* [GRASS GIS] (https://grass.osgeo.org/) - GRASS (Geographic Resources Analysis Support System) is a free and open source GIS.
-* [ILWIS] (http://52north.org/communities/ilwis/ilwis-open) - Integrated Land and Water Information System (ILWIS) is a remote sensing and GIS software.
-* [MapWindow GIS] (http://www.mapwindow.org/) - Free and open source desktop geographic information system.
-* [MapInfo] (http://www.pitneybowes.com/us/location-intelligence/geographic-information-systems/mapinfo-pro.html) - Commercial GIS.
-* [Geomedia] (http://www.hexagongeospatial.com/products/producer-suite/geomedia) - Commercial GIS.
-* [uDig] (http://udig.refractions.net/) - A GIS Framework for Eclipse (Java) and also a GIS software.
-* [SAGA] (http://www.saga-gis.org/en/index.html) - SAGA is the abbreviation for System for Automated Geoscientific Analyses.
-* [Manifold System] (http://www.manifold.net/) - Commercial GIS.
-* [AutoCAD Map 3D] (http://www.autodesk.com.br/products/autocad-map-3d/overview) - GIS AutoCAD integration.
-* [Smallworld] (https://www.gegridsolutions.com/geospatial/catalog/smallworld_core.htm) - Commercial GIS.
-* [OpenJUMP] (http://openjump.org/) - Open source Java GIS.
-* [Mapbox Studio] (https://github.com/mapbox/mapbox-studio-classic) - Desktop application for vector tile driven map design.
+* [ArcGIS](https://www.arcgis.com/features/) - GIS for working with maps and geographic information.
+* [QGIS](http://www.qgis.org/en/site/) - Cross-platform free and open-source desktop geographic information system.
+* [Terraview](http://www.dpi.inpe.br/terraview_eng/index.php) - GIS application built using the TerraLib  GIS library.
+* [gvSIG](http://www.gvsig.com/en) - Free and open source GIS.
+* [GRASS GIS](https://grass.osgeo.org/) - GRASS (Geographic Resources Analysis Support System) is a free and open source GIS.
+* [ILWIS](http://52north.org/communities/ilwis/ilwis-open) - Integrated Land and Water Information System (ILWIS) is a remote sensing and GIS software.
+* [MapWindow GIS](http://www.mapwindow.org/) - Free and open source desktop geographic information system.
+* [MapInfo](http://www.pitneybowes.com/us/location-intelligence/geographic-information-systems/mapinfo-pro.html) - Commercial GIS.
+* [Geomedia](http://www.hexagongeospatial.com/products/producer-suite/geomedia) - Commercial GIS.
+* [uDig](http://udig.refractions.net/) - A GIS Framework for Eclipse (Java) and also a GIS software.
+* [SAGA](http://www.saga-gis.org/en/index.html) - SAGA is the abbreviation for System for Automated Geoscientific Analyses.
+* [Manifold System](http://www.manifold.net/) - Commercial GIS.
+* [AutoCAD Map 3D](http://www.autodesk.com.br/products/autocad-map-3d/overview) - GIS AutoCAD integration.
+* [Smallworld](https://www.gegridsolutions.com/geospatial/catalog/smallworld_core.htm) - Commercial GIS.
+* [OpenJUMP](http://openjump.org/) - Open source Java GIS.
+* [Mapbox Studio](https://github.com/mapbox/mapbox-studio-classic) - Desktop application for vector tile driven map design.
 
 
 ## Web Map Development
 
-* [OpenLayers] (http://openlayers.org/) - Open source AJAX library.
-* [Leaflet] (http://leafletjs.com/) - Open-Source JavaScript Library for Mobile-Friendly Interactive Maps.
-* [Geomanjas] (http://www.geomajas.org/) - Open source development software for web-based and cloud based GIS applications.
-* [Cesium] (https://cesiumjs.org/) - An open-source JavaScript library for world-class 3D globes and maps.
-* [geojson-vt] (https://github.com/mapbox/geojson-vt) - A highly efficient JavaScript library for slicing GeoJSON data into vector tiles on the fly.
-* [ArcGIS JS App Generator] (https://github.com/odoe/generator-arcgis-js-app) - This is a yeoman generator for ArcGIS API for JavaScript applications.
-* [CMV - The Configurable Map Viewer] (https://github.com/cmv/cmv-app) - CMV is a community-supported open source mapping framework. CMV works with the Esri JavaScript API, ArcGIS Server, ArcGIS Online and more.
-* [Leaflet.MapboxVectorTile] (https://github.com/SpatialServer/Leaflet.MapboxVectorTile) - A Leaflet Plugin that renders Mapbox Vector Tiles on HTML5 Canvas.
-* [Flare Cluster Layer] (https://github.com/nickcam/FlareClusterLayer) - ArcGIS javascript custom graphics layer. Creates clusters and creates flares for clusters.
-* [Google Maps API Polyline String Decoder] (https://github.com/mgd722/decode-google-maps-polyline) - Function that will convert encoded polyline strings (as returned by the Google Maps API) into a list of lat/lon pairs.
-* [Mapzen Tangram] (https://github.com/tangrams/tangram) - JavaScript library for rendering 2D & 3D maps live in a web browser with WebGL, supports MVT, GeoJSON, TopoJSON.
+* [OpenLayers](http://openlayers.org/) - Open source AJAX library.
+* [Leaflet](http://leafletjs.com/) - Open-Source JavaScript Library for Mobile-Friendly Interactive Maps.
+* [Geomanjas](http://www.geomajas.org/) - Open source development software for web-based and cloud based GIS applications.
+* [Cesium](https://cesiumjs.org/) - An open-source JavaScript library for world-class 3D globes and maps.
+* [geojson-vt](https://github.com/mapbox/geojson-vt) - A highly efficient JavaScript library for slicing GeoJSON data into vector tiles on the fly.
+* [ArcGIS JS App Generator](https://github.com/odoe/generator-arcgis-js-app) - This is a yeoman generator for ArcGIS API for JavaScript applications.
+* [CMV - The Configurable Map Viewer](https://github.com/cmv/cmv-app) - CMV is a community-supported open source mapping framework. CMV works with the Esri JavaScript API, ArcGIS Server, ArcGIS Online and more.
+* [Leaflet.MapboxVectorTile](https://github.com/SpatialServer/Leaflet.MapboxVectorTile) - A Leaflet Plugin that renders Mapbox Vector Tiles on HTML5 Canvas.
+* [Flare Cluster Layer](https://github.com/nickcam/FlareClusterLayer) - ArcGIS javascript custom graphics layer. Creates clusters and creates flares for clusters.
+* [Google Maps API Polyline String Decoder](https://github.com/mgd722/decode-google-maps-polyline) - Function that will convert encoded polyline strings (as returned by the Google Maps API) into a list of lat/lon pairs.
+* [Mapzen Tangram](https://github.com/tangrams/tangram) - JavaScript library for rendering 2D & 3D maps live in a web browser with WebGL, supports MVT, GeoJSON, TopoJSON.
 
 
 ## Web Map Server
 
-* [Geoserver] (http://geoserver.org/) - WMS written in Java and relies on GeoTools. Allows users to share and edit geospatial data.
-* [Mapserver] (http://mapserver.org/) - WMS written in C.
-* [MapGuide] (https://mapguide.osgeo.org/) - Runs on Linux or Windows, supports Apache and IIS web servers, and has APIs (PHP, .NET, Java, and JavaScript) for application development.
-* [PGRestAPI] (https://github.com/spatialdev/PGRestAPI) - Node.js REST API for PostGres Spatial Entities. AKA: SpatialServer.
-* [utilery] (https://github.com/tilery/utilery) - Micro vector tile manufacturing from PostGIS.
+* [Geoserver](http://geoserver.org/) - WMS written in Java and relies on GeoTools. Allows users to share and edit geospatial data.
+* [Mapserver](http://mapserver.org/) - WMS written in C.
+* [MapGuide](https://mapguide.osgeo.org/) - Runs on Linux or Windows, supports Apache and IIS web servers, and has APIs (PHP, .NET, Java, and JavaScript) for application development.
+* [PGRestAPI](https://github.com/spatialdev/PGRestAPI) - Node.js REST API for PostGres Spatial Entities. AKA: SpatialServer.
+* [utilery](https://github.com/tilery/utilery) - Micro vector tile manufacturing from PostGIS.
 
 
 ## Radar
 
-* [PolSARpro] (https://earth.esa.int/web/polsarpro) - Open source radar image data processing software.
-* [Sarmap] (http://www.sarmap.ch/page.php?page=sarscape) - Synthetic Aperture Radar processing software.
-* [GAMMA] (http://www.gamma-rs.ch/no_cache/software.html) - Allows processing of SAR, interferometric SAR (InSAR) and differential interferometric SAR (DInSAR).
-* [Sentinel Toolboxes] (https://sentinel.esa.int/web/sentinel/toolboxes) - Free open source toolboxes for the scientific exploitation of the Sentinel missions.
-* [NANSAT] (https://github.com/nansencenter/nansat) - Nansat is a scientist friendly Python toolbox for processing 2D satellite earth observation data.
+* [PolSARpro](https://earth.esa.int/web/polsarpro) - Open source radar image data processing software.
+* [Sarmap](http://www.sarmap.ch/page.php?page=sarscape) - Synthetic Aperture Radar processing software.
+* [GAMMA](http://www.gamma-rs.ch/no_cache/software.html) - Allows processing of SAR, interferometric SAR (InSAR) and differential interferometric SAR (DInSAR).
+* [Sentinel Toolboxes](https://sentinel.esa.int/web/sentinel/toolboxes) - Free open source toolboxes for the scientific exploitation of the Sentinel missions.
+* [NANSAT](https://github.com/nansencenter/nansat) - Nansat is a scientist friendly Python toolbox for processing 2D satellite earth observation data.
 
 
 ## Lidar
 
-* [FME Desktop] (https://www.safe.com/fme/fme-desktop/) - FME is an integrated collection of Spatial ETL tools for data transformation and data translation.
-* [LAStools] (http://www.cs.unc.edu/~isenburg/lastools/) - A collection of highly-efficient, scriptable tools with multi-core batching that process LAS, compressed LAZ, Terrasolid BIN, .shp, and ASCII.
-* [FullAnalyze] (https://code.google.com/archive/p/fullanalyze/) - Handling, visualizing and processing lidar data (3D point clouds and waveforms).
-* [DielmoOpenLidar] (http://www.dielmo.com/eng/ficha-tecnologia-software.php?prod=21) - Open source software based in gvSIG for the management of LiDAR data.
-* [Global Mapper Lidar Module] (https://www.bluemarblegeo.com/products/global-mapper-lidar.php) - Lidar module for Global Mapper.
-* [Fusion] (http://forsys.cfr.washington.edu/fusion/fusionlatest.html) - Python for Lidar data.
-* [libLAS] (http://www.liblas.org/) - libLAS is a C/C++ library for reading and writing the very common LAS LiDAR format. 
-* [PyLAS] (https://pypi.python.org/pypi/PyLAS) - A python library for reading and writing LAS files.
-* [Laspy] (http://laspy.readthedocs.io/en/latest/) - Laspy is a python library for reading, modifying, and creating .LAS LIDAR files.
-* [PDAL] (http://www.pdal.io/) - PDAL is a C++ BSD library for translating and manipulating point cloud data.
+* [FME Desktop](https://www.safe.com/fme/fme-desktop/) - FME is an integrated collection of Spatial ETL tools for data transformation and data translation.
+* [LAStools](http://www.cs.unc.edu/~isenburg/lastools/) - A collection of highly-efficient, scriptable tools with multi-core batching that process LAS, compressed LAZ, Terrasolid BIN, .shp, and ASCII.
+* [FullAnalyze](https://code.google.com/archive/p/fullanalyze/) - Handling, visualizing and processing lidar data (3D point clouds and waveforms).
+* [DielmoOpenLidar](http://www.dielmo.com/eng/ficha-tecnologia-software.php?prod=21) - Open source software based in gvSIG for the management of LiDAR data.
+* [Global Mapper Lidar Module](https://www.bluemarblegeo.com/products/global-mapper-lidar.php) - Lidar module for Global Mapper.
+* [Fusion](http://forsys.cfr.washington.edu/fusion/fusionlatest.html) - Python for Lidar data.
+* [libLAS](http://www.liblas.org/) - libLAS is a C/C++ library for reading and writing the very common LAS LiDAR format. 
+* [PyLAS](https://pypi.python.org/pypi/PyLAS) - A python library for reading and writing LAS files.
+* [Laspy](http://laspy.readthedocs.io/en/latest/) - Laspy is a python library for reading, modifying, and creating .LAS LIDAR files.
+* [PDAL](http://www.pdal.io/) - PDAL is a C++ BSD library for translating and manipulating point cloud data.
 
 
 ## Geographic Data Mining
 
-* [Weka] (http://www.cs.waikato.ac.nz/ml/weka/) - Weka is a collection of machine learning algorithms for data mining tasks written in Java.
-* [GeoDMA] (https://sourceforge.net/projects/geodma/) - GeoDMA is a plugin for TerraView software, used for geographical data mining.
+* [Weka](http://www.cs.waikato.ac.nz/ml/weka/) - Weka is a collection of machine learning algorithms for data mining tasks written in Java.
+* [GeoDMA](https://sourceforge.net/projects/geodma/) - GeoDMA is a plugin for TerraView software, used for geographical data mining.
 
 
 ## Atmospheric Correction
 
-* [ATCOR] (http://www.atcor.de/) - ERDAS Imagine module.
-* [6S] (http://6s.ltdri.org/) - Open source algorithm.
+* [ATCOR](http://www.atcor.de/) - ERDAS Imagine module.
+* [6S](http://6s.ltdri.org/) - Open source algorithm.
 
 ## Libraries
 
-* [GDAL] (http://www.gdal.org/) - Geospatial Data Abstraction Library (GDAL) is a computer library.
-* [Mapnik] (http://mapnik.org/) - C++/Python/Node.js library for rendering.
-* [Terralib] (http://www.terralib.org/) - TerraLib is a GIS classes and functions open source library.
-* [GeographicLib] (http://geographiclib.sourceforge.net/) - For solving geodesic problems. Implemented in C, C++, Java, Javascript, Fortran, Python and Matlab. 
-* [Orfeo ToolBox] (https://www.orfeo-toolbox.org/) - Orfeo ToolBox (OTB) is an open-source C++ library for remote sensing images processing.
-* [Geolib] (http://www.geolib.co.uk/) - GeoLib is a fast, efficient, computational geometry library available in C++, C# and Java.
+* [GDAL](http://www.gdal.org/) - Geospatial Data Abstraction Library (GDAL) is a computer library.
+* [Mapnik](http://mapnik.org/) - C++/Python/Node.js library for rendering.
+* [Terralib](http://www.terralib.org/) - TerraLib is a GIS classes and functions open source library.
+* [GeographicLib](http://geographiclib.sourceforge.net/) - For solving geodesic problems. Implemented in C, C++, Java, Javascript, Fortran, Python and Matlab. 
+* [Orfeo ToolBox](https://www.orfeo-toolbox.org/) - Orfeo ToolBox (OTB) is an open-source C++ library for remote sensing images processing.
+* [Geolib](http://www.geolib.co.uk/) - GeoLib is a fast, efficient, computational geometry library available in C++, C# and Java.
 
 ## Python
 
-* [GeoDjango] (http://geodjango.org/) - Django geographic web framework.
-* [Landsat-util] (https://github.com/developmentseed/landsat-util) - Landsat-util is a command line utility that makes it easy to search, download, and process Landsat imagery.
-* [Rasterio] (https://github.com/mapbox/rasterio) - Rasterio employs GDAL under the hood for file I/O and raster formatting.
-* [Rasterstats] (https://github.com/perrygeo/python-rasterstats/) - Python module for summarizing geospatial raster datasets based on vector geometries.
-* [Pandas] (http://pandas.pydata.org/) - Open source library providing high-performance, easy-to-use data structures and data analysis tools for the Python.
-* [Shapely] (https://pypi.python.org/pypi/Shapely) - Manipulation and analysis of geometric objects in the Cartesian plane.
-* [Cartopy] (http://scitools.org.uk/cartopy/) - A library providing cartographic tools for python for plotting spatial data.
-* [Rtree] (http://toblerity.org/rtree/) - For efficiently querying spatial data.
-* [NodeBox-opengl] (http://www.cityinabottle.org/nodebox/) - For playing around with animations.
-* [Statsmodels] (http://statsmodels.sourceforge.net/) - Python module that allows users to explore data, estimate statistical models, and perform statistical tests.
-* [NumPy] (http://www.numpy.org/) - NumPy is the fundamental package for scientific computing with Python.
-* [geopy] (https://github.com/geopy/geopy) - geopy is a Python 2 and 3 client for several popular geocoding web services.
-* [IPython] (http://ipython.org/) - For a wondering interactive environment in which to play.
-* [FreeType] (https://code.google.com/archive/p/freetype-py/) - For converting font glyphs to polygons.
-* [PyQGIS] (http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/) - Python for QGIS.
-* [Fiona] (http://toblerity.org/fiona/) - For making it easy to read/write geospatial data formats.
-* [matplotlib] (http://matplotlib.org/) - Python 2D plotting library.
-* [networkx] (http://networkx.github.io/) - To work with networks.
-* [PySAL] (http://pysal.readthedocs.io/en/latest/) - For all your spatial econometrics needs.
-* [Descartes] (https://pypi.python.org/pypi/descartes) - Plot geometries in matplotlib.
-* [PyShp] (https://code.google.com/archive/p/pyshp/) - For reading and writing shapefiles.
-* [PyProj] (https://github.com/jswhit/pyproj) - For conversions between projections.
-* [Pyncf] (https://github.com/karimbahgat/pyncf) - Pure Python NetCDF file reading and writing.
-* [chupaESRI] (https://github.com/johnjreiser/chupaESRI) - ChupaESRI is a Python module/command line tool to extract features from ArcGIS Server map services.
-* [GeoPandas] (https://github.com/geopandas/geopandas) - Python tools for geographic data.
-* [geojsonio.py] (https://github.com/jwass/geojsonio.py) - Open GeoJSON data on geojson.io from Python. geojsonio.py also contains a command line utility that is a Python port of geojsonio-cli.
-* [Ogcserver] (https://github.com/mapnik/OGCServer) - Python WMS implementation using Mapnik.
-* [RSGISLib] (http://www.rsgislib.org/) - The Remote Sensing and GIS software library (RSGISLib) is a collection of tools for processing remote sensing and GIS datasets. The tools are accessed using Python bindings or an XML interface.
-* [Scikit-image] (http://scikit-image.org/) - Scikit-image is a collection of algorithms for image processing.
+* [GeoDjango](http://geodjango.org/) - Django geographic web framework.
+* [Landsat-util](https://github.com/developmentseed/landsat-util) - Landsat-util is a command line utility that makes it easy to search, download, and process Landsat imagery.
+* [Rasterio](https://github.com/mapbox/rasterio) - Rasterio employs GDAL under the hood for file I/O and raster formatting.
+* [Rasterstats](https://github.com/perrygeo/python-rasterstats/) - Python module for summarizing geospatial raster datasets based on vector geometries.
+* [Pandas](http://pandas.pydata.org/) - Open source library providing high-performance, easy-to-use data structures and data analysis tools for the Python.
+* [Shapely](https://pypi.python.org/pypi/Shapely) - Manipulation and analysis of geometric objects in the Cartesian plane.
+* [Cartopy](http://scitools.org.uk/cartopy/) - A library providing cartographic tools for python for plotting spatial data.
+* [Rtree](http://toblerity.org/rtree/) - For efficiently querying spatial data.
+* [NodeBox-opengl](http://www.cityinabottle.org/nodebox/) - For playing around with animations.
+* [Statsmodels](http://statsmodels.sourceforge.net/) - Python module that allows users to explore data, estimate statistical models, and perform statistical tests.
+* [NumPy](http://www.numpy.org/) - NumPy is the fundamental package for scientific computing with Python.
+* [geopy](https://github.com/geopy/geopy) - geopy is a Python 2 and 3 client for several popular geocoding web services.
+* [IPython](http://ipython.org/) - For a wondering interactive environment in which to play.
+* [FreeType](https://code.google.com/archive/p/freetype-py/) - For converting font glyphs to polygons.
+* [PyQGIS](http://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/) - Python for QGIS.
+* [Fiona](http://toblerity.org/fiona/) - For making it easy to read/write geospatial data formats.
+* [matplotlib](http://matplotlib.org/) - Python 2D plotting library.
+* [networkx](http://networkx.github.io/) - To work with networks.
+* [PySAL](http://pysal.readthedocs.io/en/latest/) - For all your spatial econometrics needs.
+* [Descartes](https://pypi.python.org/pypi/descartes) - Plot geometries in matplotlib.
+* [PyShp](https://code.google.com/archive/p/pyshp/) - For reading and writing shapefiles.
+* [PyProj](https://github.com/jswhit/pyproj) - For conversions between projections.
+* [Pyncf](https://github.com/karimbahgat/pyncf) - Pure Python NetCDF file reading and writing.
+* [chupaESRI](https://github.com/johnjreiser/chupaESRI) - ChupaESRI is a Python module/command line tool to extract features from ArcGIS Server map services.
+* [GeoPandas](https://github.com/geopandas/geopandas) - Python tools for geographic data.
+* [geojsonio.py](https://github.com/jwass/geojsonio.py) - Open GeoJSON data on geojson.io from Python. geojsonio.py also contains a command line utility that is a Python port of geojsonio-cli.
+* [Ogcserver](https://github.com/mapnik/OGCServer) - Python WMS implementation using Mapnik.
+* [RSGISLib](http://www.rsgislib.org/) - The Remote Sensing and GIS software library (RSGISLib) is a collection of tools for processing remote sensing and GIS datasets. The tools are accessed using Python bindings or an XML interface.
+* [Scikit-image](http://scikit-image.org/) - Scikit-image is a collection of algorithms for image processing.
 
 
 ## PaaS - Platform as a Service
 
-* [Google Maps API] (https://developers.google.com/maps/) - Google's PaaS (Platform as a Service) for Geocoding or analysis/processing services.
-* [Microsoft Bing API] (https://www.bingmapsportal.com/) - Microsoft Bing Maps API.
-* [OpenStreetMap API] (http://wiki.openstreetmap.org/wiki/API_v0.6) - OpenStreetMap API.
-* [Mapbox.js] (https://www.mapbox.com/mapbox.js/api/v2.4.0/) - MapBox Javascript API.
-* [Mapbox GL JS] (https://www.mapbox.com/mapbox-gl-js/api/) - MapBox WebGL Javascript API.
+* [Google Maps API](https://developers.google.com/maps/) - Google's PaaS (Platform as a Service) for Geocoding or analysis/processing services.
+* [Microsoft Bing API](https://www.bingmapsportal.com/) - Microsoft Bing Maps API.
+* [OpenStreetMap API](http://wiki.openstreetmap.org/wiki/API_v0.6) - OpenStreetMap API.
+* [Mapbox.js](https://www.mapbox.com/mapbox.js/api/v2.4.0/) - MapBox Javascript API.
+* [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/) - MapBox WebGL Javascript API.
 
 
-## SaaS – Software as a Service
+## SaaS - Software as a Service
 
-* [ArcGIS Online] (https://www.arcgis.com/home/) - ArcGIS Online GIS platform for mapping ans spatial analysis.
-* [CartoDB] (https://cartodb.com/) -  Cloud computing platform that provides GIS and web mapping tools for display in a web browser.
-* [Mapbox] (https://www.mapbox.com/) - Plataform for web map design and manipulation.
+* [ArcGIS Online](https://www.arcgis.com/home/) - ArcGIS Online GIS platform for mapping ans spatial analysis.
+* [CartoDB](https://cartodb.com/) -  Cloud computing platform that provides GIS and web mapping tools for display in a web browser.
+* [Mapbox](https://www.mapbox.com/) - Plataform for web map design and manipulation.
 
 
-## DaaS – Data as a Service
+## DaaS - Data as a Service
 
-* [Apple Maps] (https://mapsconnect.apple.com/) - Apple map service.
-* [Google Maps] (https://www.google.com.br/maps) - Google map service.
-* [Microsoft Bing Maps] (http://www.bing.com/mapspreview) - Microsoft map service.
-* [OpenStreetMap] (http://www.openstreetmap.org/) - OpenStreeMap map service.
+* [Apple Maps](https://mapsconnect.apple.com/) - Apple map service.
+* [Google Maps](https://www.google.com.br/maps) - Google map service.
+* [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
+* [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
 
 
 ## Java
 
-* [Geotools] (http://www.geotools.org/) - GeoTools is an open source Java library that provides tools for geospatial data.
-* [Geonetwork] (http://geonetwork-opensource.org/) - GeoNetwork is a catalog application to manage spatially referenced resources.
-* [JTS Topology Suite] (http://www.vividsolutions.com/jts/jtshome.htm) - JTS Topology Suite is an API of 2D spatial predicates and functions.
-* [GeOxygene] (https://sourceforge.net/projects/oxygene-project/) - Provide an open framework which implements OGC/ISO specifications for the development and deployment of GIS applications.
-* [Gisgraphy] (http://www.gisgraphy.com/) - Open source framework that offers the ability to do geolocalisation and geocoding via Java APIs or REST webservices.
-* [JGeocoder] (http://jgeocoder.sourceforge.net/) - Free Java Geocoder.
-* [Spatial4j] (https://github.com/locationtech/spatial4j) - Spatial4j is a general purpose geospatial ASL licensed open-source Java library.
-* [Geoapi] (http://www.geoapi.org/) - GeoAPI provides a set of Java language programming interfaces for geospatial applications.
-* [Openmap] (https://github.com/openmap-java/openmap) - Open Source JavaBeans-based programmer's toolkit.
-* [Apache SIS] (http://sis.apache.org/) - Apache Spatial Information System (SIS) is a free software, Java language library for developing geospatial applications.
-* [World Wind Java SDK] (http://worldwind.arc.nasa.gov/java/) - Nasa cross-platform Java SDK.
+* [Geotools](http://www.geotools.org/) - GeoTools is an open source Java library that provides tools for geospatial data.
+* [Geonetwork](http://geonetwork-opensource.org/) - GeoNetwork is a catalog application to manage spatially referenced resources.
+* [JTS Topology Suite](http://www.vividsolutions.com/jts/jtshome.htm) - JTS Topology Suite is an API of 2D spatial predicates and functions.
+* [GeOxygene](https://sourceforge.net/projects/oxygene-project/) - Provide an open framework which implements OGC/ISO specifications for the development and deployment of GIS applications.
+* [Gisgraphy](http://www.gisgraphy.com/) - Open source framework that offers the ability to do geolocalisation and geocoding via Java APIs or REST webservices.
+* [JGeocoder](http://jgeocoder.sourceforge.net/) - Free Java Geocoder.
+* [Spatial4j](https://github.com/locationtech/spatial4j) - Spatial4j is a general purpose geospatial ASL licensed open-source Java library.
+* [Geoapi](http://www.geoapi.org/) - GeoAPI provides a set of Java language programming interfaces for geospatial applications.
+* [Openmap](https://github.com/openmap-java/openmap) - Open Source JavaBeans-based programmer's toolkit.
+* [Apache SIS](http://sis.apache.org/) - Apache Spatial Information System (SIS) is a free software, Java language library for developing geospatial applications.
+* [World Wind Java SDK](http://worldwind.arc.nasa.gov/java/) - Nasa cross-platform Java SDK.
 
 
 ## C Sharp
 
-* [SharpMap] (http://sharpmap.codeplex.com/) - SharpMap is an easy-to-use mapping library for use in web and desktop applications.
-* [DotSpatial] (https://dotspatial.codeplex.com/) - DotSpatial is a geographic information system library written for .NET 4.
-* [NTS Net Topology Suite] (https://github.com/NetTopologySuite/NetTopologySuite) - A .NET GIS solution that is fast and reliable for the .NET platform.
-* [Geo] (https://github.com/sibartlett/Geo) - A geospatial library for .NET
-* [SharpKml] (https://sharpkml.codeplex.com/) - Is able to read/write both KML files and KMZ files.
+* [SharpMap](http://sharpmap.codeplex.com/) - SharpMap is an easy-to-use mapping library for use in web and desktop applications.
+* [DotSpatial](https://dotspatial.codeplex.com/) - DotSpatial is a geographic information system library written for .NET 4.
+* [NTS Net Topology Suite](https://github.com/NetTopologySuite/NetTopologySuite) - A .NET GIS solution that is fast and reliable for the .NET platform.
+* [Geo](https://github.com/sibartlett/Geo) - A geospatial library for .NET
+* [SharpKml](https://sharpkml.codeplex.com/) - Is able to read/write both KML files and KMZ files.
 
 
 ## C++
 
-* [GEOS] (https://trac.osgeo.org/geos/) - GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).
-* [Capaware] (https://en.wikipedia.org/wiki/Capaware) - 3D terrain representation with multilayer representation.
-* [libspatialindex] (https://github.com/libspatialindex/libspatialindex) - C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.
-* [Spatial] (https://sourceforge.net/projects/spatial/) - Spatial is a generic header-only C++ library providing multi-dimensional in-memory containers, iterators and functionals.
-* [geojson-vt-cpp] (https://github.com/mapbox/geojson-vt-cpp) - Port to C++ of JS GeoJSON-VT for slicing GeoJSON into vector tiles on the fly.
-* [Supercluster] (https://github.com/mapbox/supercluster.hpp) - A C++14 port of supercluster, a fast 2D point clustering library for use in interactive maps.
-* [Mapbox GL Native] (https://github.com/mapbox/mapbox-gl-native) - Render Mapbox styles in mobile, desktop, and node applications using C++ and OpenGL.
-* [Mapzen Tangram-ES] (https://github.com/tangrams/tangram-es) - C++ library for rendering 2D and 3D maps using OpenGL ES 2 with custom styling and interactions
-* [Mapnik Vector Tile] (https://github.com/mapbox/mapnik-vector-tile) - Mapnik C++ implemention of Mapbox Vector Tile specification.
-* [Vector Tiles Producer] (https://github.com/vross/vector-tiles-producer) - Command line tool in C++ to creates vector tiles for a given area at chosen zoom levels using a Mapnik XML.
-* [libGeoTiff] (https://trac.osgeo.org/geotiff/) - Manipulate TIFF based interchange format for georeferenced raster imagery.
-* [Orfeo ToolBox] (https://www.orfeo-toolbox.org/) - Orfeo TooLBox (OTB) is an open-source C++ library for remote sensing images processing, distributed under the CeCILL-v2 licence.
-* [ITK] (https://itk.org/) - ITK is an open-source, cross-platform system that provides developers with an extensive suite of software tools for image analysis.
-* [RSGISLib] (https://bitbucket.org/petebunting/rsgislib/src/bf7933996822?at=default) - The Remote Sensing and GIS software library (RSGISLib) is a collection of tools for processing remote sensing and GIS datasets. The tools are accessed using Python bindings or an XML interface.
+* [GEOS](https://trac.osgeo.org/geos/) - GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).
+* [Capaware](https://en.wikipedia.org/wiki/Capaware) - 3D terrain representation with multilayer representation.
+* [libspatialindex](https://github.com/libspatialindex/libspatialindex) - C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.
+* [Spatial](https://sourceforge.net/projects/spatial/) - Spatial is a generic header-only C++ library providing multi-dimensional in-memory containers, iterators and functionals.
+* [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) - Port to C++ of JS GeoJSON-VT for slicing GeoJSON into vector tiles on the fly.
+* [Supercluster](https://github.com/mapbox/supercluster.hpp) - A C++14 port of supercluster, a fast 2D point clustering library for use in interactive maps.
+* [Mapbox GL Native](https://github.com/mapbox/mapbox-gl-native) - Render Mapbox styles in mobile, desktop, and node applications using C++ and OpenGL.
+* [Mapzen Tangram-ES](https://github.com/tangrams/tangram-es) - C++ library for rendering 2D and 3D maps using OpenGL ES 2 with custom styling and interactions
+* [Mapnik Vector Tile](https://github.com/mapbox/mapnik-vector-tile) - Mapnik C++ implemention of Mapbox Vector Tile specification.
+* [Vector Tiles Producer](https://github.com/vross/vector-tiles-producer) - Command line tool in C++ to creates vector tiles for a given area at chosen zoom levels using a Mapnik XML.
+* [libGeoTiff](https://trac.osgeo.org/geotiff/) - Manipulate TIFF based interchange format for georeferenced raster imagery.
+* [Orfeo ToolBox](https://www.orfeo-toolbox.org/) - Orfeo TooLBox (OTB) is an open-source C++ library for remote sensing images processing, distributed under the CeCILL-v2 licence.
+* [ITK](https://itk.org/) - ITK is an open-source, cross-platform system that provides developers with an extensive suite of software tools for image analysis.
+* [RSGISLib](https://bitbucket.org/petebunting/rsgislib/src/bf7933996822?at=default) - The Remote Sensing and GIS software library (RSGISLib) is a collection of tools for processing remote sensing and GIS datasets. The tools are accessed using Python bindings or an XML interface.
 
 
 ## C
 
-* [Shapefile C Library] (http://shapelib.maptools.org/) - Provides the ability to write simple C programs for reading, writing and updating (to a limited extent) .shp and .dbf files.
-* [Libuv] (https://github.com/libuv/libuv) - Cross-platform asynchronous I/O.
-* [Datamaps] (https://github.com/ericfischer/datamaps) - This is a tool for indexing large lists of geographic points or lines and dynamically generating map tiles from the index for display.
+* [Shapefile C Library](http://shapelib.maptools.org/) - Provides the ability to write simple C programs for reading, writing and updating (to a limited extent) .shp and .dbf files.
+* [Libuv](https://github.com/libuv/libuv) - Cross-platform asynchronous I/O.
+* [Datamaps](https://github.com/ericfischer/datamaps) - This is a tool for indexing large lists of geographic points or lines and dynamically generating map tiles from the index for display.
  
 
 
 ## Ruby
 
-* [Geokit] (http://geokit.rubyforge.org/) - A Ruby gem & Rails plugin for easier map-based applications.
-* [Rgeo] (https://github.com/rgeo/rgeo) - RGeo is a geospatial data library for Ruby. It provides an implementation of the Open Geospatial Consortium's Simple Features Specification
-* [Rgeo Shapefile] (https://github.com/rgeo/rgeo-shapefile) - Optional module for RGeo for reading geospatial data from ESRI shapefiles.
-* [Rgeo GeoJSON] (https://github.com/rgeo/rgeo-geojson) - RGeo component for reading and writing GeoJSON.
-* [ffi-geos] (RGeo component for reading and writing GeoJSON) - Low-level ruby bindings to GEOS library.
-* [PostGIS ActiveRecord Adapter] (https://github.com/rgeo/activerecord-postgis-adapter) - ActiveRecord adapter for PostGIS.
-* [SpatiaLite ActiveRecord Adapter] (https://github.com/rgeo/activerecord-spatialite-adapter) - ActiveRecord adapter for Spatialite.
-* [Mongoid Geospatial] (https://github.com/nofxx/mongoid-geospatial) - A Mongoid Extension that simplifies the use of MongoDB spatial features.
-* [Ruby Geocoder] (http://www.rubygeocoder.com/) - Integration with geocoding services.
+* [Geokit](http://geokit.rubyforge.org/) - A Ruby gem & Rails plugin for easier map-based applications.
+* [Rgeo](https://github.com/rgeo/rgeo) - RGeo is a geospatial data library for Ruby. It provides an implementation of the Open Geospatial Consortium's Simple Features Specification
+* [Rgeo Shapefile](https://github.com/rgeo/rgeo-shapefile) - Optional module for RGeo for reading geospatial data from ESRI shapefiles.
+* [Rgeo GeoJSON](https://github.com/rgeo/rgeo-geojson) - RGeo component for reading and writing GeoJSON.
+* [ffi-geos](RGeo component for reading and writing GeoJSON) - Low-level ruby bindings to GEOS library.
+* [PostGIS ActiveRecord Adapter](https://github.com/rgeo/activerecord-postgis-adapter) - ActiveRecord adapter for PostGIS.
+* [SpatiaLite ActiveRecord Adapter](https://github.com/rgeo/activerecord-spatialite-adapter) - ActiveRecord adapter for Spatialite.
+* [Mongoid Geospatial](https://github.com/nofxx/mongoid-geospatial) - A Mongoid Extension that simplifies the use of MongoDB spatial features.
+* [Ruby Geocoder](http://www.rubygeocoder.com/) - Integration with geocoding services.
 
 
 ## CSS
 
-* [CartoCSS] (https://www.mapbox.com/tilemill/docs/manual/carto/) - TileMills language.
-* [MapCSS] (http://wiki.openstreetmap.org/wiki/MapCSS) - MapCSS is a CSS-like language for map stylesheets.
+* [CartoCSS](https://www.mapbox.com/tilemill/docs/manual/carto/) - TileMills language.
+* [MapCSS](http://wiki.openstreetmap.org/wiki/MapCSS) - MapCSS is a CSS-like language for map stylesheets.
 
 
 ## Julia 
 
-* [RasterIO.jl] (https://github.com/wkearn/RasterIO.jl) - Simple Raster Formats for Julia.
-* [OpenStreetMaps.jl] (https://github.com/tedsteiner/OpenStreetMap.jl) - This package provides basic functionality for parsing, viewing, and working with OpenStreetMap map data.
+* [RasterIO.jl](https://github.com/wkearn/RasterIO.jl) - Simple Raster Formats for Julia.
+* [OpenStreetMaps.jl](https://github.com/tedsteiner/OpenStreetMap.jl) - This package provides basic functionality for parsing, viewing, and working with OpenStreetMap map data.
 
 
 ## R
 
-* [sp] (https://cran.r-project.org/web/packages/sp/index.html) - Classes and Methods for Spatial Data.
-* [rgdal] (https://cran.r-project.org/web/packages/rgdal/index.html) - Bindings for the Geospatial Data Abstraction Library.
-* [raster] (https://cran.r-project.org/web/packages/raster/raster.pdf) - Reading, writing, manipulating, analyzing and modeling of gridded spatial data.
-* [ggplot2] (http://ggplot2.org/) - ggplot2 is a plotting system for R.
-* [ggmap] (https://cran.r-project.org/web/packages/ggmap/index.html) - Spatial Visualization with ggplot2.
-* [rgeos] (https://cran.r-project.org/web/packages/rgeos/index.html) - Interface to Geometry Engine - Open Source (GEOS) using the C API for topology operations on geometries.
-* [rgrass7] (https://cran.r-project.org/web/packages/rgrass7/index.html) - Interface Between GRASS 7 GIS and R.
-* [Rnetcdf] (https://cran.r-project.org/web/packages/RNetCDF/index.html) - Interface to NetCDF Datasets.
-* [RSAGA] (https://cran.r-project.org/web/packages/RSAGA/index.html) - SAGA Geoprocessing and Terrain Analysis in R.
-* [RODBC] (https://cran.r-project.org/web/packages/RODBC/index.html) - ODBC Database Access.
-* [RPyGeo] (https://cran.r-project.org/web/packages/RPyGeo/index.html) - ArcGIS Geoprocessing in R via Python.
-* [shapefiles] (https://cran.r-project.org/web/packages/shapefiles/index.html) - Read and Write ESRI Shapefiles.
-* [Rgooglemaps] (https://cran.r-project.org/web/packages/RgoogleMaps/index.html) - Overlays on Google map tiles in R.
-* [leafletR] (https://cran.r-project.org/web/packages/leafletR/index.html) - Interactive Web-Maps Based on the Leaflet JavaScript Library.
-* [maptools] (https://cran.r-project.org/web/packages/maptools/index.html) - Tools for Reading and Handling Spatial Objects.
-* [RArcInfo] (https://cran.r-project.org/web/packages/RArcInfo/index.html) - Functions to import data from Arc/Info V7.x binary coverages.
-* [Akima] (https://cran.r-project.org/web/packages/akima/index.html) - Interpolation of Irregularly and Regularly Spaced Data.
-* [maps] (https://cran.r-project.org/web/packages/maps/index.html) - Draw Geographical Maps.
-* [PBSmapping] (https://cran.r-project.org/web/packages/PBSmapping/index.html) - Mapping Fisheries Data and Spatial Analysis Tools.
-* [Landsat] (https://cran.r-project.org/web/packages/landsat/index.html) - Radiometric and topographic correction of satellite imagery.
-* [spatstat] (https://cran.r-project.org/web/packages/spatstat/index.html) - Spatial Point Pattern Analysis, Model-Fitting, Simulation, Tests.
-* [splancs] (https://cran.r-project.org/web/packages/splancs/index.html) - Spatial and Space-Time Point Pattern Analysis.
-* [plotKML] (https://cran.r-project.org/web/packages/plotKML/index.html) - Visualization of Spatial and Spatio-Temporal Objects in Google Earth.
-* [OpenStreetMap] (https://cran.r-project.org/web/packages/OpenStreetMap/index.html) - Access to Open Street Map Raster Images.
-* [GEOmap] (https://cran.r-project.org/web/packages/GEOmap/index.html) - Topographic and Geologic Mapping.
-* [rworldmap] (https://cran.r-project.org/web/packages/rworldmap/index.html) - Mapping Global Data.
-* [rasterVis] (https://cran.r-project.org/web/packages/rasterVis/index.html) - Visualization Methods for Raster Data.
-* [spdep] (https://cran.r-project.org/web/packages/spdep/index.html) - Spatial Dependence: Weighting Schemes, Statistics and Models.
-* [spacetime] (https://cran.r-project.org/web/packages/spacetime/index.html) - Classes and Methods for Spatio-Temporal Data.
-* [geoR] (https://cran.r-project.org/web/packages/geoR/index.html) - Analysis of Geostatistical Data.
-* [ecespa] (https://cran.r-project.org/web/packages/ecespa/index.html) - Functions for Spatial Point Pattern Analysis.
-* [mapproj] (https://cran.r-project.org/web/packages/mapproj/index.html) - Map Projections.
-* [gstat] (https://cran.r-project.org/web/packages/gstat/index.html) - Spatio-Temporal Geostatistical Modelling, Prediction and Simulation.
-* [intamap] (https://cran.r-project.org/web/packages/intamap/index.html) - Procedures for automated interpolation.
+* [sp](https://cran.r-project.org/web/packages/sp/index.html) - Classes and Methods for Spatial Data.
+* [rgdal](https://cran.r-project.org/web/packages/rgdal/index.html) - Bindings for the Geospatial Data Abstraction Library.
+* [raster](https://cran.r-project.org/web/packages/raster/raster.pdf) - Reading, writing, manipulating, analyzing and modeling of gridded spatial data.
+* [ggplot2](http://ggplot2.org/) - ggplot2 is a plotting system for R.
+* [ggmap](https://cran.r-project.org/web/packages/ggmap/index.html) - Spatial Visualization with ggplot2.
+* [rgeos](https://cran.r-project.org/web/packages/rgeos/index.html) - Interface to Geometry Engine - Open Source (GEOS) using the C API for topology operations on geometries.
+* [rgrass7](https://cran.r-project.org/web/packages/rgrass7/index.html) - Interface Between GRASS 7 GIS and R.
+* [Rnetcdf](https://cran.r-project.org/web/packages/RNetCDF/index.html) - Interface to NetCDF Datasets.
+* [RSAGA](https://cran.r-project.org/web/packages/RSAGA/index.html) - SAGA Geoprocessing and Terrain Analysis in R.
+* [RODBC](https://cran.r-project.org/web/packages/RODBC/index.html) - ODBC Database Access.
+* [RPyGeo](https://cran.r-project.org/web/packages/RPyGeo/index.html) - ArcGIS Geoprocessing in R via Python.
+* [shapefiles](https://cran.r-project.org/web/packages/shapefiles/index.html) - Read and Write ESRI Shapefiles.
+* [Rgooglemaps](https://cran.r-project.org/web/packages/RgoogleMaps/index.html) - Overlays on Google map tiles in R.
+* [leafletR](https://cran.r-project.org/web/packages/leafletR/index.html) - Interactive Web-Maps Based on the Leaflet JavaScript Library.
+* [maptools](https://cran.r-project.org/web/packages/maptools/index.html) - Tools for Reading and Handling Spatial Objects.
+* [RArcInfo](https://cran.r-project.org/web/packages/RArcInfo/index.html) - Functions to import data from Arc/Info V7.x binary coverages.
+* [Akima](https://cran.r-project.org/web/packages/akima/index.html) - Interpolation of Irregularly and Regularly Spaced Data.
+* [maps](https://cran.r-project.org/web/packages/maps/index.html) - Draw Geographical Maps.
+* [PBSmapping](https://cran.r-project.org/web/packages/PBSmapping/index.html) - Mapping Fisheries Data and Spatial Analysis Tools.
+* [Landsat](https://cran.r-project.org/web/packages/landsat/index.html) - Radiometric and topographic correction of satellite imagery.
+* [spatstat](https://cran.r-project.org/web/packages/spatstat/index.html) - Spatial Point Pattern Analysis, Model-Fitting, Simulation, Tests.
+* [splancs](https://cran.r-project.org/web/packages/splancs/index.html) - Spatial and Space-Time Point Pattern Analysis.
+* [plotKML](https://cran.r-project.org/web/packages/plotKML/index.html) - Visualization of Spatial and Spatio-Temporal Objects in Google Earth.
+* [OpenStreetMap](https://cran.r-project.org/web/packages/OpenStreetMap/index.html) - Access to Open Street Map Raster Images.
+* [GEOmap](https://cran.r-project.org/web/packages/GEOmap/index.html) - Topographic and Geologic Mapping.
+* [rworldmap](https://cran.r-project.org/web/packages/rworldmap/index.html) - Mapping Global Data.
+* [rasterVis](https://cran.r-project.org/web/packages/rasterVis/index.html) - Visualization Methods for Raster Data.
+* [spdep](https://cran.r-project.org/web/packages/spdep/index.html) - Spatial Dependence: Weighting Schemes, Statistics and Models.
+* [spacetime](https://cran.r-project.org/web/packages/spacetime/index.html) - Classes and Methods for Spatio-Temporal Data.
+* [geoR](https://cran.r-project.org/web/packages/geoR/index.html) - Analysis of Geostatistical Data.
+* [ecespa](https://cran.r-project.org/web/packages/ecespa/index.html) - Functions for Spatial Point Pattern Analysis.
+* [mapproj](https://cran.r-project.org/web/packages/mapproj/index.html) - Map Projections.
+* [gstat](https://cran.r-project.org/web/packages/gstat/index.html) - Spatio-Temporal Geostatistical Modelling, Prediction and Simulation.
+* [intamap](https://cran.r-project.org/web/packages/intamap/index.html) - Procedures for automated interpolation.
 
 ## JavaScript
-* [Heatmap.js] (https://www.patrick-wied.at/static/heatmapjs/) - A heatmap implementation for Javascript.
-* [Thermo.js] (https://github.com/dazuma/thermo.js) - Another heatmap implementation for Javascript.
-* [Heatcanvas.js] (https://github.com/sunng87/heatcanvas) - Yet another heatmap implementation for Javascript.
+* [Heatmap.js](https://www.patrick-wied.at/static/heatmapjs/) - A heatmap implementation for Javascript.
+* [Thermo.js](https://github.com/dazuma/thermo.js) - Another heatmap implementation for Javascript.
+* [Heatcanvas.js](https://github.com/sunng87/heatcanvas) - Yet another heatmap implementation for Javascript.
 
 
 ## Node.js
 
-* [Turf.js] (http://turfjs.org/) - Advanced geospatial analysis for browsers and node.
-* [JSTS] (https://github.com/bjornharrtell/jsts) - Port of the Java JTS library.
-* [Spatial] (https://github.com/troufster/spatial) - A 2d spatial hash module for node.js.
-* [PGRestAPI] (https://github.com/spatialdev/PGRestAPI) - Node.js REST API for PostGres Spatial Entities.
-* [Supercluster] (https://github.com/mapbox/supercluster) - A crazy fast geospatial point clustering library for browsers and Node.
-* [SQLite3] (https://github.com/mapbox/node-sqlite3) - Asynchronous, non-blocking SQLite3 bindings for Node.js.
-* [Windshaft] (https://github.com/CartoDB/Windshaft) - A Node.js map tile library for PostGIS and torque.js, with CartoCSS styling.
+* [Turf.js](http://turfjs.org/) - Advanced geospatial analysis for browsers and node.
+* [JSTS](https://github.com/bjornharrtell/jsts) - Port of the Java JTS library.
+* [Spatial](https://github.com/troufster/spatial) - A 2d spatial hash module for node.js.
+* [PGRestAPI](https://github.com/spatialdev/PGRestAPI) - Node.js REST API for PostGres Spatial Entities.
+* [Supercluster](https://github.com/mapbox/supercluster) - A crazy fast geospatial point clustering library for browsers and Node.
+* [SQLite3](https://github.com/mapbox/node-sqlite3) - Asynchronous, non-blocking SQLite3 bindings for Node.js.
+* [Windshaft](https://github.com/CartoDB/Windshaft) - A Node.js map tile library for PostGIS and torque.js, with CartoCSS styling.
 
 
 ## Mobile Development
 
-* [Mapbox Android SDK] (https://www.mapbox.com/android-sdk/) - An open source toolset for building mapping applications for Android devices.
-* [Mapbox iOS SDK] (https://www.mapbox.com/ios-sdk/) - An open source toolset for building mapping applications for iPhone and iPad devices.
-* [Google Maps API for Android] (https://developers.google.com/maps/android/) - Google maps for Android.
-* [Google Maps API for iOS] (https://developers.google.com/maps/ios/) - Google maps for iOS.
-* [Nutiteq Maps SDK] (http://www.nutiteq.com/nutiteq-sdk/overview/) - C++ maps library for iOS, Android, Windows Phone and Xamarin with bindings for Java, ObjectiveC and C#.
-* [WhirlyGlobe/Maply] (http://mousebird.github.io/WhirlyGlobe/) - Objective C code that is able to read and render vector tiles(and style with mapnik xml) on iOS devices.
+* [Mapbox Android SDK](https://www.mapbox.com/android-sdk/) - An open source toolset for building mapping applications for Android devices.
+* [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) - An open source toolset for building mapping applications for iPhone and iPad devices.
+* [Google Maps API for Android](https://developers.google.com/maps/android/) - Google maps for Android.
+* [Google Maps API for iOS](https://developers.google.com/maps/ios/) - Google maps for iOS.
+* [Nutiteq Maps SDK](http://www.nutiteq.com/nutiteq-sdk/overview/) - C++ maps library for iOS, Android, Windows Phone and Xamarin with bindings for Java, ObjectiveC and C#.
+* [WhirlyGlobe/Maply](http://mousebird.github.io/WhirlyGlobe/) - Objective C code that is able to read and render vector tiles(and style with mapnik xml) on iOS devices.
 
 
 ## Visualization 
 
-* [Processing] (https://processing.org/) - Processing is a flexible software sketchbook and a language for learning how to code within the context of the visual arts.
-* [P5.js] (https://p5js.org/) - Javascript library that starts with the original goal of Processing.
-* [Processing.py] (http://py.processing.org/) - Python mode for Processing.
-* [D3.js] (https://d3js.org/) - D3.js is a JavaScript library for manipulating documents based on data.
-* [openFrameworks] (http://openframeworks.cc/) - openFrameworks is an open source C++ toolkit for creative coding.
-* [Folium] (https://github.com/python-visualization/folium) - Python Data. Leaflet.js Maps.
-* [Blender GIS] (https://github.com/domlysz/BlenderGIS) - Blender addons to make the bridge between Blender and geographic data.
-* [tippiecannoe] (https://github.com/mapbox/tippecanoe) - Build vector tilesets from large collections of GeoJSON features.
-* [Kosmtik] (https://github.com/kosmtik/kosmtik) - Very lite but extendable mapping framework to create Mapnik ready maps with OpenStreetMap data (and more).
-* [mplleaflet] (https://github.com/jwass/mplleaflet) - Easily convert matplotlib plots from Python into interactive Leaflet web maps.
+* [Processing](https://processing.org/) - Processing is a flexible software sketchbook and a language for learning how to code within the context of the visual arts.
+* [P5.js](https://p5js.org/) - Javascript library that starts with the original goal of Processing.
+* [Processing.py](http://py.processing.org/) - Python mode for Processing.
+* [D3.js](https://d3js.org/) - D3.js is a JavaScript library for manipulating documents based on data.
+* [openFrameworks](http://openframeworks.cc/) - openFrameworks is an open source C++ toolkit for creative coding.
+* [Folium](https://github.com/python-visualization/folium) - Python Data. Leaflet.js Maps.
+* [Blender GIS](https://github.com/domlysz/BlenderGIS) - Blender addons to make the bridge between Blender and geographic data.
+* [tippiecannoe](https://github.com/mapbox/tippecanoe) - Build vector tilesets from large collections of GeoJSON features.
+* [Kosmtik](https://github.com/kosmtik/kosmtik) - Very lite but extendable mapping framework to create Mapnik ready maps with OpenStreetMap data (and more).
+* [mplleaflet](https://github.com/jwass/mplleaflet) - Easily convert matplotlib plots from Python into interactive Leaflet web maps.
 
 
 ## Tools
 
-* [TileMill] (https://github.com/mapbox/tilemill) - TileMill is a modern map design studio powered by Node.js and Mapnik.
-* [DataPillager] (https://github.com/gdherbert/DataPillager) - Download data from Esri service.
-* [Osm2pgsql] (https://github.com/openstreetmap/osm2pgsql) - osm2pgsql is a tool for loading OpenStreetMap data into a PostgreSQL.
+* [TileMill](https://github.com/mapbox/tilemill) - TileMill is a modern map design studio powered by Node.js and Mapnik.
+* [DataPillager](https://github.com/gdherbert/DataPillager) - Download data from Esri service.
+* [Osm2pgsql](https://github.com/openstreetmap/osm2pgsql) - osm2pgsql is a tool for loading OpenStreetMap data into a PostgreSQL.
 
 
 ## Cheat sheets
 
-* [Fiona-Rasterio-Shapely Cheat Sheet] (https://github.com/sgillies/frs-cheat-sheet) - A cheat sheet for Fiona/Rasterio/Shapely command-line geodata tools.
-* [GDAL] (https://github.com/dwtkns/gdal-cheat-sheet) - Cheat sheet for GDAL/OGR command-line tools.
-* [PostGIS] (http://www.postgis.us/downloads/postgis21_cheatsheet.pdf) - Cheat sheet for PostGIS.
-* [PostGIS 2] (https://gist.github.com/kidpixo/5698476) 
-* [PostGIS Raster] (http://www.postgis.us/downloads/postgis20_raster_cheatsheet.pdf) 
+* [Fiona-Rasterio-Shapely Cheat Sheet](https://github.com/sgillies/frs-cheat-sheet) - A cheat sheet for Fiona/Rasterio/Shapely command-line geodata tools.
+* [GDAL](https://github.com/dwtkns/gdal-cheat-sheet) - Cheat sheet for GDAL/OGR command-line tools.
+* [PostGIS](http://www.postgis.us/downloads/postgis21_cheatsheet.pdf) - Cheat sheet for PostGIS.
+* [PostGIS 2](https://gist.github.com/kidpixo/5698476) 
+* [PostGIS Raster](http://www.postgis.us/downloads/postgis20_raster_cheatsheet.pdf) 
 
 ## Data Sources
 
-* [TZ Timezone Shapefiles] (http://efele.net/maps/tz/world/) - Polygon boundaries of world timezones.
-* [USGS Earth Explorer] (http://earthexplorer.usgs.gov/) - Provides online search,metadata export, and data download for earth science data from the archives of the USGS.
-* [GeoNames] (www.geonames.org) - The GeoNames geographical database covers all countries and contains over eight million place names (cities, postal codes, countries) that are available for download free of charge.
-* [Mapzen] (https://mapzen.com/metro-extracts) - It provides data in OSM/PBF and Esri shapefile formats for popular cities.
-* [Geofabrik] (http://download.geofabrik.de/) - This is another source of prepared OpenStreetMap data. This distribution is generally built nightly and comes in OSM XML, pbf, and shapefile (for very popular areas) formats.
-* [Natural Earth] (www.naturalearthdata.com) - This site offers public domain map data sets that contain both raster and vector data.
-* [ASTER Data] (https://lpdaac.usgs.gov/dataset_discovery/aster) - Download ASTER data.
+* [TZ Timezone Shapefiles](http://efele.net/maps/tz/world/) - Polygon boundaries of world timezones.
+* [USGS Earth Explorer](http://earthexplorer.usgs.gov/) - Provides online search,metadata export, and data download for earth science data from the archives of the USGS.
+* [GeoNames](www.geonames.org) - The GeoNames geographical database covers all countries and contains over eight million place names (cities, postal codes, countries) that are available for download free of charge.
+* [Mapzen](https://mapzen.com/metro-extracts) - It provides data in OSM/PBF and Esri shapefile formats for popular cities.
+* [Geofabrik](http://download.geofabrik.de/) - This is another source of prepared OpenStreetMap data. This distribution is generally built nightly and comes in OSM XML, pbf, and shapefile (for very popular areas) formats.
+* [Natural Earth](www.naturalearthdata.com) - This site offers public domain map data sets that contain both raster and vector data.
+* [ASTER Data](https://lpdaac.usgs.gov/dataset_discovery/aster) - Download ASTER data.
 
 
 ## Resources
 
-* [Cartographical Map Projections] (http://www.progonos.com/furuti/MapProj/Normal/TOC/cartTOC.html) - A good introduction to projected coordinate systems
-* [Spatialreference.org] (http://spatialreference.org/) - Source for coordinate system information.
-* [ESRI Shapefile Specs] (http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf) - Shapefile specifications.
-* [GeoJSON.io] (http://geojson.io/) - geojson.io is a quick, simple tool for creating, viewing, and sharing maps.
+* [Cartographical Map Projections](http://www.progonos.com/furuti/MapProj/Normal/TOC/cartTOC.html) - A good introduction to projected coordinate systems
+* [Spatialreference.org](http://spatialreference.org/) - Source for coordinate system information.
+* [ESRI Shapefile Specs](http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf) - Shapefile specifications.
+* [GeoJSON.io](http://geojson.io/) - geojson.io is a quick, simple tool for creating, viewing, and sharing maps.
 
 
 ## References
 
-* [Essential Python Geospatial Libraries] (http://carsonfarmer.com/2013/07/essential-python-geo-libraries/) 
-* [GeoJSON] (https://github.com/tmcw/awesome-geojson)
-* [Vector Tiles] (https://github.com/mapbox/awesome-vector-tiles)
-* [Awesome Spatial] (https://github.com/RoboDonut/awesome-spatial/blob/master/README.md)
-* [Awesome SQLite] (https://github.com/planetopendata/awesome-sqlite) 
-* [Awesome Python] (https://github.com/vinta/awesome-python/blob/master/README.md)
-* [GeoRails] (http://daniel-azuma.com/articles/georails/)
-
-
-
-
-
-
+* [Essential Python Geospatial Libraries](http://carsonfarmer.com/2013/07/essential-python-geo-libraries/) 
+* [GeoJSON](https://github.com/tmcw/awesome-geojson)
+* [Vector Tiles](https://github.com/mapbox/awesome-vector-tiles)
+* [Awesome Spatial](https://github.com/RoboDonut/awesome-spatial/blob/master/README.md)
+* [Awesome SQLite](https://github.com/planetopendata/awesome-sqlite) 
+* [Awesome Python](https://github.com/vinta/awesome-python/blob/master/README.md)
+* [GeoRails](http://daniel-azuma.com/articles/georails/)


### PR DESCRIPTION
Most links weren't rendering because of a space between `[link name] (url)`, and some of the anchors weren't working because of how GitHub creates anchor slugs. Fixed all except C++, because GitHub creates the anchor `#c`, which is already in use.