### PR TITLE
Add Terra Draw to JavaScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
 * [SQLite3](https://github.com/mapbox/node-sqlite3) - Asynchronous, non-blocking SQLite3 bindings for Node.js.
 * [Supercluster](https://github.com/mapbox/supercluster) - A crazy fast geospatial point clustering library for browsers and Node.
 * [SuperMap iClient for JavaScript](http://iclient.supermap.io) - Cloud GIS web client development platform supportted by SuperMap.
+* [Terra Draw](https://github.com/JamesLMilner/terra-draw) - A cross provider JavaScript library for drawing on maps
 * [TerriaJS](https://github.com/TerriaJS/terriajs) - A library for building rich, web-based geospatial data explorers. 
 * [Thermo.js](https://github.com/dazuma/thermo.js) - Another heatmap implementation for Javascript.
 * [tilegarden](https://github.com/azavea/tilegarden) - Serverless raster and vector map tile generation using Mapnik and AWS Lambda.


### PR DESCRIPTION
This PR adds Terra Draw, a map drawing library that works across map providers (Mapbox, MapLibre, Leaflet, OpenLayers etc) to the JavaScript section of the README.