### PR TITLE
Add Phantom Tide to SaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ with GNSS (global navigation satellite system).
 * [NextGIS](http://nextgis.com/) - A cloud geospatial service that allows you to create web GIS right in the browser.
 * [OpenCage Geocoding API](https://geocoder.opencagedata.com/) - An API aggregating multiple open geo datasources (OpenStreetMap and others).
 * [OpenMapTiles](https://openmaptiles.com/) - Vector tiles and map services as service, self-hosted or off-line.
+* [Phantom Tide](https://github.com/tg12/phantomtide) - Real-time geospatial intelligence platform for maritime and airspace monitoring, combining vessel tracking, ADS-B flight activity, official notices, environmental context, and satellite detections in a single live map workflow.
 * [World Monitor](https://www.worldmonitor.app) - Real-time global intelligence platform aggregating live military flight tracking (ADS-B), AIS vessel monitoring, GPS jamming heatmaps, conflict event overlays, satellite data, and geopolitical risk scores on an interactive 3D globe.
 
 


### PR DESCRIPTION
This adds Phantom Tide to the SaaS section.

Disclosure: I maintain Phantom Tide and am submitting it for inclusion.

Repository:
https://github.com/tg12/phantomtide

Live app:
https://phantom.labs.jamessawyer.co.uk

Why it fits:
Phantom Tide is a hosted geospatial intelligence platform for maritime and airspace monitoring. It brings together vessel tracking, ADS-B flight activity, official notices, environmental context, and satellite detections in a single live map workflow.
