### PR TITLE
Add Namazue Console to Web Map Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
 * [vue-azure-maps](https://github.com/rickyruiz/vue-azure-maps) - Integrate Azure Maps in your Vue application.
 
 
+- [Namazue Console](https://github.com/Hybirdss/namazue-console) - Japan-wide earthquake intelligence console with GMPE intensity computation, real-time P/S wave propagation, PLATEAU 3D Tiles, and infrastructure fragility assessment. Built with MapLibre GL JS + deck.gl. [Live demo](https://namazue.dev)
 ## Web Map Server
 
 * [52North WPS](http://52north.org/communities/geoprocessing/wps/index.html) - The 52°North Web Processing Service (WPS) enables the deployment of geo-processes on the web in a standardized way. It features a pluggable architecture for processes and data encodings. The implementation is based on the current OpenGIS specification: 05-007r7. Its focus was the creation of an extensible framework to provide algorithms for generalization on the web.


### PR DESCRIPTION
Adds Namazue Console to the Web Map Development section.

Namazue is a Japan-wide earthquake intelligence console with GMPE intensity computation (Si & Midorikawa 1999), real-time P/S wave propagation, and infrastructure fragility assessment. Built with MapLibre GL JS + deck.gl.

Repo: https://github.com/Hybirdss/namazue-console
Live: https://namazue.dev

Disclosure: I'm the author of Namazue Console.