### PR TITLE
Add ZipCheckup - US ZIP-level environmental safety data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1467,7 +1467,7 @@ for geospatial and tabular data.
 * [Sentinel 2 AWS](http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/) - Sentinel 2 data on Amazon S3.
 * [TZ Timezone Shapefiles](http://efele.net/maps/tz/world/) - Polygon boundaries of world timezones.
 * [USGS Earth Explorer](http://earthexplorer.usgs.gov/) - Provides online search,metadata export, and data download for earth science data from the archives of the USGS.
-* [ZipCheckup](https://zipcheckup.com/) - Free ZIP-level environmental safety data platform covering water quality, air quality, PFAS, radon, lead, flood risk and 11 more verticals across 42K US ZIP codes. Public API, CC BY 4.0.
+* [ZipCheckup](https://github.com/artakulov/us-water-quality-data) - Free ZIP-level environmental safety data platform covering water quality, air quality, PFAS, radon, lead, flood risk and 11 more verticals across 42K US ZIP codes. Public API, CC BY 4.0.
 * [99 Boundaries](https://99boundaries.com/) - Download or generate maritime and land country boundaries from OpenStreetMap in GeoJSON and other file formats.
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -1467,6 +1467,7 @@ for geospatial and tabular data.
 * [Sentinel 2 AWS](http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/) - Sentinel 2 data on Amazon S3.
 * [TZ Timezone Shapefiles](http://efele.net/maps/tz/world/) - Polygon boundaries of world timezones.
 * [USGS Earth Explorer](http://earthexplorer.usgs.gov/) - Provides online search,metadata export, and data download for earth science data from the archives of the USGS.
+* [ZipCheckup](https://zipcheckup.com/) - Free ZIP-level environmental safety data platform covering water quality, air quality, PFAS, radon, lead, flood risk and 11 more verticals across 42K US ZIP codes. Public API, CC BY 4.0.
 * [99 Boundaries](https://99boundaries.com/) - Download or generate maritime and land country boundaries from OpenStreetMap in GeoJSON and other file formats.
 
 ## Resources


### PR DESCRIPTION
ZipCheckup is a free public platform aggregating 50+ federal environmental datasets (EPA, CDC, USGS, FEMA) into ZIP-level safety profiles. Covers 17 verticals, 42K+ ZIP codes. Public API at api.zipcheckup.com/v1/. Open data CC BY 4.0.