### PR TITLE
Add CoordinateMapper - free coordinate conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,7 +1438,7 @@ for geospatial and tabular data.
 * [veins](https://github.com/sommer/veins) - Open source vehicular network simulation framework.
 * [eodag](https://github.com/CS-SI/eodag) - Command line tool and a plugin-oriented Python framework for searching, aggregating results and downloading remote sensed images while offering a unified API for data access regardless of the data provider.
 * [nextgisweb](https://github.com/nextgis/nextgisweb) - Server based application/server-side framework for geodata storage, management and visualization.
-
+* [CoordinateMapper](https://coordinatemapper.com/) - Free browser-based tool for converting between lat/long, UTM, UK Grid References, Easting/Northing, MGRS, DMS and DDM. Includes map preview and CSV/KML/DXF export.
 
 ## Cheat sheets
 


### PR DESCRIPTION
CoordinateMapper is a free browser-based tool that converts coordinates between all major formats, lat/long (DD, DMS, DDM), UTM, UK Grid References, UK E/N and MGRS across both WGS84 and OSGB36 datums. Paste any coordinate, verify it on the live map, and export to CSV, KML or DXF. Also includes an extensive library of guides and troubleshooting resources covering coordinate systems, datums, projections and common conversion errors. No sign-up, no limits