### PR TITLE
Add Japan Neighborhoods to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1461,6 +1461,7 @@ for geospatial and tabular data.
 * [Geofabrik](http://download.geofabrik.de/) - This is another source of prepared OpenStreetMap data. This distribution is generally built nightly and comes in OSM XML, pbf, and shapefile (for very popular areas) formats.
 * [GeoNames](http://www.geonames.org/) - The GeoNames geographical database covers all countries and contains over eight million place names (cities, postal codes, countries) that are available for download free of charge.
 * [INPE Database](http://www.dgi.inpe.br/CDSR/) - Download free satellite data including MODIS, Landsat (1-8), ResourceSat (1-2) and CBERS (2 and 2B) data.
+* [Japan Neighborhoods](https://japanneighborhoods.com) - Free English-language dataset of Tokyo crime statistics covering 5,078 neighborhoods (chōme) across Tokyo 23 wards + Tama area, 7 years (2018-2024, 36,222 records) sourced from Tokyo Metropolitan Police open data. Includes interactive Leaflet crime map, safety grading (A+ to F), and cost-of-living index. CC BY licensed.
 * [INPE CBERS4A and Amazonia1 Database](http://www2.dgi.inpe.br/catalogo/explore) - Download free CBERS 4A and Amazonia 1 images.
 * [MapTiler Data](https://www.maptiler.com/data/) - Ready-to-use geographic data. The very best of open geospatial data, processed and packaged for your next on-prem project. Available as vector/raster tiles and in GIS formats.
 * [Mapzen](https://mapzen.com/metro-extracts) - It provides data in OSM/PBF and Esri shapefile formats for popular cities.


### PR DESCRIPTION
Adds **Japan Neighborhoods** to the Data Sources section.

Free English-language dataset covering:
- 5,078 Tokyo neighborhoods (chōme) across 23 wards + Tama area
- 7 years of crime statistics (2018-2024, 36,222 records)
- Sourced from Tokyo Metropolitan Police open data
- Includes Leaflet-based interactive crime map, safety grading (A+ to F), cost-of-living index
- CC BY licensed
- REST API: https://japanneighborhoods.com/developers