### PR TITLE
Add auto-sea-way to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,7 @@ with GNSS (global navigation satellite system).
 ## Rust
 
 * [A/B Street](https://github.com/dabreegster/abstreet) - A traffic simulation game exploring how small changes to roads affect cyclists, transit users, pedestrians, and drivers.
+* [auto-sea-way](https://github.com/auto-sea-way/asw) - Open source maritime auto-routing engine that builds a global water-surface routing graph from OSM land polygons using an adaptive H3 hexagonal grid cascade.
 * [geoarrow-rs](https://github.com/kylebarron/geoarrow-rs) - GeoArrow in Rust and WebAssembly with vectorized geometry operations.
 * [geographiclib-rs](https://github.com/georust/geographiclib-rs) - A subset of geographiclib implemented in Rust.
 * [Hecate](https://github.com/mapbox/Hecate) - Fast Geospatial Feature Storage API.


### PR DESCRIPTION
Adds [auto-sea-way](https://github.com/auto-sea-way/asw) to the Rust section.

auto-sea-way is an open source maritime auto-routing engine written in pure Rust. It builds a global water-surface routing graph from OSM land polygons using an adaptive H3 hexagonal grid cascade (res-3 ocean through res-13 in narrow passages like Suez/Panama), with an HTTP API for route queries.

Placed alphabetically after "A/B Street" in the Rust section.