### PR TITLE
Add Crime Brasil (DaaS - Data as a Service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ with GNSS (global navigation satellite system).
 * [Google Maps](https://www.google.com.br/maps) - Google map service.
 * [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
 * [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
+* [Crime Brasil](https://crimebrasil.com.br) - Open-data platform consolidating and geocoding Brazilian crime data. ~3M incidents geocoded to neighborhood level in Rio Grande do Sul, municipality-level for MG and RJ. Free REST API, CC BY 4.0.
 
 
 ## Google Earth Engine


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) to DaaS - Data as a Service.

Crime Brasil is an open-data platform consolidating criminal incidents from Brazilian state police (SSP) sources, geocoded at neighborhood level for Rio Grande do Sul (2.99M incidents 2022–2025, 99.99% geocoded across 79,024 neighborhoods and 497 municipalities), plus municipality-level coverage for Minas Gerais and Rio de Janeiro, and national federal-highway/PRF data.

Free REST API, CSV and Parquet exports, daily updates, CC BY 4.0 license.

Disclosure: I'm the maintainer.