### PR TITLE
Add geo-utils to C++ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ with GNSS (global navigation satellite system).
 * [entwine](https://github.com/connormanning/entwine) - Entwine is a data organization library for massive point clouds, designed to conquer datasets of hundreds of billions of points as well as desktop-scale point clouds.
 * [GDAL](http://www.gdal.org/) - Geospatial Data Abstraction Library (GDAL) is a computer library that serve as a translator library for raster and vector geospatial data formats.
 * [gdalcubes](https://github.com/appelmar/gdalcubes) - gdalcubes is a library to represent collections of Earth Observation (EO) images as on demand data cubes (or multidimensional arrays).
+* [geo-utils](https://github.com/gistrec/geo-utils) - Header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon.
 * [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) - Port to C++ of JS GeoJSON-VT for slicing GeoJSON into vector tiles on the fly.
 * [GEOS](https://trac.osgeo.org/geos/) - GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).
 * [gSLICr](https://github.com/carlren/gSLICr) - Real-time super-pixel segmentation.


### PR DESCRIPTION
Adds [geo-utils](https://github.com/gistrec/geo-utils) — a header-only C++17 library for spherical (lat/lng) geometry on Earth coordinates: distance, bearing, polygon area, point-in-polygon, and path proximity.

- License: Apache-2.0
- No runtime dependencies
- C++17, CMake 3.14+
- CI on Linux (gcc/clang), macOS, Windows; downstream `find_package` smoke-tested on all three

Inserted alphabetically in the **C++** section between `gdalcubes` and `geojson-vt-cpp`. Adjacent to existing entries like `GEOS`, `S2 Geometry`, and `Boost Geometry`, but fills a gap for projects that just need lightweight spherical lat/lng calculations without pulling in the full weight of those libraries.