### PR TITLE
Add gisweep to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1425,6 +1425,7 @@ with GNSS (global navigation satellite system).
 * [gdal-mini](https://github.com/rouault/gdal-mini) - Minimal version of GDAL.
 * [Generic Mapping Tools](https://github.com/GenericMappingTools/gmt) - GMT is an open source collection of about 90 command-line tools for manipulating geographic and Cartesian data sets.
 * [GeoGig](http://geogig.org/) - GeoGig is a Distributed Version Control System (DVCS) specially designed to handle geospatial data efficiently.
+* [gisweep](https://github.com/enisgetmez/gisweep) - GIS vulnerability scanner for ArcGIS REST, OGC (WMS/WFS), and embedded web maps. Audits anonymous write capabilities, exposed admin endpoints, PII fields in feature schemas, and outdated server / client-side libraries; every finding is mapped to KVKK / GDPR articles. Active-mode probes are gated behind explicit opt-in.
 * [GISWATER](https://www.giswater.org/?lang=en) - Open-source software for water cycle management (water supply and urban drainage).
 * [GrADS](http://cola.gmu.edu/grads/) - The Grid Analysis and Display System (GrADS) is an interactive desktop tool that is used for easy access, manipulation, and visualization of earth science data.
 * [imscript](https://github.com/mnhrdt/imscript) - A collection of small and standalone utilities for image processing.


### PR DESCRIPTION
Adds [gisweep](https://github.com/enisgetmez/gisweep) — an open-source
GIS vulnerability scanner — to the **Tools** section.

**What it covers**

* ArcGIS REST: anonymous service enumeration, anonymous write capability
  on FeatureServers, exposed `/arcgis/admin`, PII fields, outdated
  server CVEs.
* OGC (WMS / WFS) over GeoServer / MapServer / QGIS Server / deegree:
  anonymous capabilities, WFS-Transactional anonymous write, PII fields
  via `DescribeFeatureType`, unbounded `GetFeature` dump detection,
  outdated-server CVE matching, and a safe-payload active probe for
  CVE-2024-36401 (GeoServer OGC-filter RCE).
* Embedded web maps (Playwright headless Chromium): leaked API keys
  (Google, Mapbox, AWS, GitHub, Stripe, JWT, …), CORS misconfig,
  outdated client-side library CVEs (Leaflet, OpenLayers, Mapbox GL,
  Cesium, ArcGIS API for JavaScript).
* Cross-cutting compliance overlay: every finding is pre-mapped to KVKK
  Madde 12 / 9 and GDPR Art. 32 / 5(1)(f) / Art. 9, plus aggregate
  findings (≥5 PII layers exposed anonymously, admin + open data, etc.).

**Distribution**

* PyPI: `pip install gisweep`
* GitHub: https://github.com/enisgetmez/gisweep
* License: Apache-2.0
* CI matrix: Linux × macOS × Windows / Python 3.11–3.13

Active-mode checks (anonymous write, default credentials, SSRF,
CVE-2024-36401 probe) are gated behind two explicit opt-ins
(`--active --i-own-this-target`) and every active call is appended to
`~/.gisweep/audit.jsonl`.

I checked Tools is the closest fit; happy to move the entry to a
different section (e.g. Python) if you'd prefer.