### PR TITLE
Rename geo-utils to geo-utils-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ with GNSS (global navigation satellite system).
 * [entwine](https://github.com/connormanning/entwine) - Entwine is a data organization library for massive point clouds, designed to conquer datasets of hundreds of billions of points as well as desktop-scale point clouds.
 * [GDAL](http://www.gdal.org/) - Geospatial Data Abstraction Library (GDAL) is a computer library that serve as a translator library for raster and vector geospatial data formats.
 * [gdalcubes](https://github.com/appelmar/gdalcubes) - gdalcubes is a library to represent collections of Earth Observation (EO) images as on demand data cubes (or multidimensional arrays).
-* [geo-utils](https://github.com/gistrec/geo-utils) - Header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon.
+* [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) - Header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon.
 * [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) - Port to C++ of JS GeoJSON-VT for slicing GeoJSON into vector tiles on the fly.
 * [GEOS](https://trac.osgeo.org/geos/) - GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).
 * [gSLICr](https://github.com/carlren/gSLICr) - Real-time super-pixel segmentation.


### PR DESCRIPTION
The library [previously added](https://github.com/sacridini/Awesome-Geospatial/pull/191) as `geo-utils` was renamed to `geo-utils-cpp` to avoid a Repology naming conflict (see gistrec/geo-utils-cpp#11).

This PR updates the existing entry in **C++** to use the new name and URL:

- Link text: `geo-utils` → `geo-utils-cpp`
- URL: `https://github.com/gistrec/geo-utils` → `https://github.com/gistrec/geo-utils-cpp`

The old URL still redirects, but the rename means GitHub stars/issues badges and any future linking should use the new canonical name. Description, license, and alphabetical position are unchanged.