### PR TITLE
Add Postali to DaaS — free postal codes API (Mexico, Colombia, Spain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ with GNSS (global navigation satellite system).
 * [Google Maps](https://www.google.com.br/maps) - Google map service.
 * [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
 * [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
+* [Postali](https://postali.app/api) - Free postal codes (zip codes) REST API for Mexico, Colombia, and Spain. ~200k entries from official sources (SEPOMEX, GeoNames). No API key, no signup, no monthly quota.
 
 
 


### PR DESCRIPTION
Adds [Postali](https://postali.app/api) under the **DaaS - Data as a Service** section, alongside other geocoded-data REST APIs like Crime Brasil.

Postali is a public REST API for postal codes (códigos postales / zip codes) covering Mexico, Colombia, and Spain. Truly free: no API key, no signup, no monthly request cap.

- Eight endpoints: lookup by postal code, validation, fuzzy search, listings by administrative level (state → municipality → settlement), and bulk lookups (up to 100/request)
- HTTPS-only, CORS open, JSON
- Cacheable responses (`Cache-Control: public, s-maxage=604800`) — most traffic served from Cloudflare edge
- Sources are official: SEPOMEX (MX, ~157k entries), GeoNames (CO ~3.7k, ES ~38k)
- Documentation: https://postali.app/api/docs