### PR TITLE
Add Zip-Codes API to DaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ with GNSS (global navigation satellite system).
 * [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
 * [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
 * [Postali](https://postali.app/api) - Free postal codes (zip codes) REST API for Mexico, Colombia, and Spain. ~200k entries from official sources (SEPOMEX, GeoNames). No API key, no signup, no monthly quota.
+* [Zip-Codes](https://www.zip-codes.com/api/) - REST API for US ZIP and Canadian postal code lookup, address validation, radius search, demographics, and boundaries.
 
 
 


### PR DESCRIPTION
  Adds Zip-Codes to the DaaS — Data as a Service section.

  REST API providing US ZIP, ZIP+4, and Canadian postal code lookup; address parsing and standardization; radius search
  (centroid and spatial polygon intersection); point-to-point distance; demographics (Census ACS 2011–2024); and
  boundary data (Census, congressional district, school district).

  - Docs: https://api.zip-codes.com/docs
  - OpenAPI: https://api.zip-codes.com/v2/openapi.json
  - Free tier available