### PR TITLE
Add Warnely to DaaS - Data as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ with GNSS (global navigation satellite system).
 * [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
 * [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
 * [Postali](https://postali.app/api) - Free postal codes (zip codes) REST API for Mexico, Colombia, and Spain. ~200k entries from official sources (SEPOMEX, GeoNames). No API key, no signup, no monthly quota.
+* [Warnely](https://warnely.com/developers) - Composite travel-safety scores for 180 countries (FCDO + US State + Global Peace Index + WGI + live incident wire). Free REST API, OpenAPI 3.1 spec, CC BY 4.0. Returns per-country lat/lng centroids alongside score and tier.
 * [Zip-Codes](https://www.zip-codes.com/api/) - REST API for US ZIP and Canadian postal code lookup, address validation, radius search, demographics, and boundaries.
 
 


### PR DESCRIPTION
Adds [Warnely](https://warnely.com/developers) to the **DaaS - Data as a Service** section.

## Why this fits the geospatial list

Warnely publishes per-country travel-safety records that each include:
- ISO 3166-1 alpha-2 + alpha-3 codes
- Region grouping
- **Geographic centroid (lat/lng)** — useful for map-based risk visualisation
- Composite risk score (0–100)
- Tier classification

The lat/lng centroid is exposed via the OpenAPI spec on every country record, so the dataset is directly consumable by geospatial workflows that need to map risk to coordinates (e.g. duty-of-care dashboards, travel-risk overlays, journey-planning tools).

## Details

- **API base URL**: https://warnely.com/api/v1
- **OpenAPI 3.1 spec**: https://warnely.com/openapi.json
- **Interactive docs**: https://warnely.com/api-docs
- **GitHub repo**: https://github.com/sn-lui/warnely-openapi
- **Auth**: None
- **CORS**: Open
- **License**: CC BY 4.0

## Sample

```
curl https://warnely.com/api/v1/countries/TH
```

Returns the composite safety score, region, and country centroid alongside the editorial detail.