### PR TITLE
Move emem to new MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
     - [DaaS - Data as a Service](#daas---data-as-a-service)
     - [Google Earth Engine](#google-earth-engine)
     - [Deep Learning](#deep-learning)
+    - [MCP Servers](#mcp-servers)
     - [C](#c-1)
     - [C++](#c)
     - [C Sharp](#c-sharp)
@@ -372,7 +373,6 @@ with GNSS (global navigation satellite system).
 * [CSV2GEO](https://csv2geo.com) - Batch geocoder using excel/csv file, text or API as an input and get latitude, longitude and an interactive map as output.
 * [DataV Atlas](https://datav.aliyun.com/portal/school/atlas/area_generator) - Cloud AI platform for online real-time analysis and visualization of geo bigdata. Powered by Alibaba Cloud with Qwen.
 * [Dekart](https://dekart.xyz) - Open-source alternative to CARTO. SQL to interactive map platform that connects BigQuery, Snowflake, and PostGIS. Self-host or cloud.
-* [emem](https://github.com/Vortx-AI/emem) - Earth memory MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.
 * [Fulcrum](http://www.fulcrumapp.com/) - A mobile data collection platform that allows you to build, deploy, & collect field data with your own customizable data collection apps.
 * [Geobox](https://en.geobox.ir/) - Geobox is a suite of products that together cover all stages of building an online GIS.
 * [Geodocs](https://geodocs.io/) - GIS-powered project management platform for construction and infrastructure projects with support for KML, KMZ, Shapefile, and GeoJSON uploads, PostGIS database, MVT vector tiles, dynamic forms, and Mapbox GL JS visualization.
@@ -467,6 +467,10 @@ with GNSS (global navigation satellite system).
 * [tsl](https://github.com/TorchSpatiotemporal/tsl) - PyTorch library for processing spatiotemporal data.
 * [WaterNet](https://github.com/treigerm/WaterNet) - A convolutional neural network that identifies water in satellite images.
 * [YOLT](https://github.com/avanetten/yolt) - You Only Look Twice: Rapid Multi-Scale Object Detection In Satellite Imagery.
+
+## MCP Servers
+
+* [emem](https://github.com/Vortx-AI/emem) - Earth memory MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.
 
 ## C
 


### PR DESCRIPTION
Moves emem from the SaaS section to a new **MCP Servers** section.

emem is an open-source MCP server, not a SaaS product. MCP (Model Context Protocol) servers are a growing category in the geospatial space, and having a dedicated section makes it easier to find them as more appear.

No new entries added, just a reorganization.