### PR TITLE
Add OpenWaterAtlas to DaaS - Data as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ with GNSS (global navigation satellite system).
 * [Google Maps](https://www.google.com.br/maps) - Google map service.
 * [Microsoft Bing Maps](http://www.bing.com/mapspreview) - Microsoft map service.
 * [OpenStreetMap](http://www.openstreetmap.org/) - OpenStreeMap map service.
+* [OpenWaterAtlas](https://openwateratlas.com/en/datasets/) - Integrated open dataset joining 2,928 dive/kite/surf/freedive sites with per-spot climate aggregates (Open-Meteo + ERA5), 112,548 OBIS + GBIF marine species observations, and the 34,876-route OpenFlights direct-route airline graph. CSV + Parquet, CC-BY 4.0, DOI 10.5281/zenodo.20668393.
 * [Postali](https://postali.app/api) - Free postal codes (zip codes) REST API for Mexico, Colombia, and Spain. ~200k entries from official sources (SEPOMEX, GeoNames). No API key, no signup, no monthly quota.
 * [Warnely](https://warnely.com/developers) - Composite travel-safety scores for 180 countries (FCDO + US State + Global Peace Index + WGI + live incident wire). Free REST API, OpenAPI 3.1 spec, CC BY 4.0. Returns per-country lat/lng centroids alongside score and tier.
 * [Zip-Codes](https://www.zip-codes.com/api/) - REST API for US ZIP and Canadian postal code lookup, address validation, radius search, demographics, and boundaries.


### PR DESCRIPTION
Adding the OpenWaterAtlas dataset to the DaaS section. It's a CC-BY 4.0 open dataset that integrates four already-open layers (spots + climate + marine species + airline routes) into a single citable bundle.

- 2,928 named dive/kite/surf/freedive sites with WGS-84 coords, water-temp range, depth, MPA flag, best months
- 749,568 daily climate aggregates (Open-Meteo + ERA5), 24,576 monthly aggregates
- 112,548 OBIS + GBIF marine species occurrences (with terrestrial-noise filter)
- 34,876 OpenFlights direct routes (CC-BY 3.0 upstream)

Available via Zenodo (DOI 10.5281/zenodo.20668393), Kaggle, and HuggingFace Datasets. Landing page with full methodology + citation block at <https://openwateratlas.com/en/datasets/>.

Inserted alphabetically (after OpenStreetMap, before Postali) to match the section's existing order. Happy to tweak the entry format if you prefer a different style.