### PR TITLE
Add Mapbase to SaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ with GNSS (global navigation satellite system).
 * [LatLng](https://www.latlng.work/) - OSM-based geocoding, reverse geocoding, places, static maps, and tile APIs.
 * [LYRASENSE](https://lyrasense.com) - Agentic AI platform for satellite data analysis with a notebook environment and Google Earth Engine integration.
 * [MapAtlas](https://mapatlas.eu/) - A mapping REST API providing geocoding, directions, route optimization, matrix, isochrone, MVT vector tiles, map matching, and GeoEnrich services using OpenStreetMap and proprietary data.
+* [Mapbase](https://mapbase.dev/) - Location registry API that turns coordinates into official locations, custom zones, hierarchy, geometry, and SEO-ready location context. Includes autocomplete, resolve, postcodes, LAU regions, and a TypeScript SDK.
 * [Mapbox](https://www.mapbox.com/) - Platform for web map design and manipulation.
 * [MapTiler Cloud](https://www.maptiler.com/cloud/) - Maps API for web & mobile developers. Customize maps, upload or create own geodata and publish online.
 * [Mercator](https://mercator.blue/) - Gridded earth data (weather, ocean, air quality, elevation) as value-encoded Web Mercator tiles, with an open-source MapLibre SDK for colormapped rasters, wind and current streamlines, arrows and contours.


### PR DESCRIPTION
## Summary

- Adds [Mapbase](https://mapbase.dev/) to the **SaaS - Software as a Service** section in alphabetical order.
- Mapbase is a location registry API that turns coordinates into official locations, custom zones, hierarchy, geometry, and SEO-ready location context.

## Test plan

- [x] Entry follows existing list format (`* [Name](URL) - Description.`)
- [x] Placed alphabetically between MapAtlas and Mapbox
- [x] Link points to the public site (https://mapbase.dev/)


Made with [Cursor](https://cursor.com)