### PR TITLE
Add Działkopedia (Polish land-parcel due-diligence SaaS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ with GNSS (global navigation satellite system).
 * [CSV2GEO](https://csv2geo.com) - Batch geocoder using excel/csv file, text or API as an input and get latitude, longitude and an interactive map as output.
 * [DataV Atlas](https://datav.aliyun.com/portal/school/atlas/area_generator) - Cloud AI platform for online real-time analysis and visualization of geo bigdata. Powered by Alibaba Cloud with Qwen.
 * [Dekart](https://dekart.xyz) - Open-source alternative to CARTO. SQL to interactive map platform that connects BigQuery, Snowflake, and PostGIS. Self-host or cloud.
+* [Działkopedia](https://dzialkopedia.pl) - Polish land-parcel due-diligence tool: cadastral boundaries (GUGiK), orthophoto, transaction prices (RCN) and municipal zoning plans on an OpenStreetMap-based map.
 * [Fulcrum](http://www.fulcrumapp.com/) - A mobile data collection platform that allows you to build, deploy, & collect field data with your own customizable data collection apps.
 * [Geobox](https://en.geobox.ir/) - Geobox is a suite of products that together cover all stages of building an online GIS.
 * [Geocode.xyz](https://geocode.xyz/) - Reverse geocoding, forward geocoding, and geoparsing API.


### PR DESCRIPTION
Adds Działkopedia (https://dzialkopedia.pl) under SaaS. A Polish parcel due-diligence web service combining GUGiK cadastral/orthophoto, RCN transaction prices and municipal zoning on an OpenStreetMap-based map — same category as AssessorSearch and BC Property Check already in the list. Thanks for maintaining this.