### PR TITLE
Add Sunshine Atlas to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,7 @@ for geospatial and tabular data.
 * [RoadDetections](https://github.com/microsoft/RoadDetections) - Road detections from Microsoft Maps aerial imagery.
 * [Scale Open Datasets](https://scale.com/open-datasets?utm_campaign=Spatial%20Awareness&utm_medium=email&utm_source=Revue%20newsletter) - Open Datasets for Autonomous Driving.
 * [Sentinel 2 AWS](http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/) - Sentinel 2 data on Amazon S3.
+* [Sunshine Atlas](https://sunshineatlas.com/data/) - Open dataset (CC BY 4.0, DOI) of monthly sunshine hours, temperature, rainfall and sea-surface-temperature climate normals for 3,833 destinations worldwide; interactive globe, mirrored on GitHub, Zenodo, Hugging Face and Kaggle.
 * [TZ Timezone Shapefiles](http://efele.net/maps/tz/world/) - Polygon boundaries of world timezones.
 * [USGS Earth Explorer](http://earthexplorer.usgs.gov/) - Provides online search,metadata export, and data download for earth science data from the archives of the USGS.
 * [World Atlas TopoJSON](https://github.com/topojson/world-atlas) - Natural Earth's vector data as TopoJSON.


### PR DESCRIPTION
Hi — I'm the maker of Sunshine Atlas, a free, no-signup, ad-free interactive globe + open dataset (CC BY 4.0, DOI) ranking 3,833 flyable destinations by monthly sunshine hours and climate normals. Adding it under **Data Sources** because it's an open, downloadable CC BY 4.0 climate dataset, like the other Data Sources entries. Happy to tweak the wording or placement — thanks for maintaining this list!