### PR TITLE
Add Knowground to SaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ with GNSS (global navigation satellite system).
 * [GISCO data distribution API](https://gisco-services.ec.europa.eu/distribution/v2/) - European Commission data source for administrative regions and boundaries.
 * [GraphHopper Route Optimization API](https://www.graphhopper.com/route-optimization/) - Solves various vehicle routing problems.
 * [Honeycomb Maps](https://honeycombmaps.com) - Browser-based enterprise map dashboard software, with real-time filtering and metric calculation.
+* [Knowground](https://www.knowground.com) - Free, no-signup lookup of per-address US civic and environmental data - FEMA flood zone, ground elevation, NCES public schools, EPA hazard facilities, FCC broadband, and Census/ACS - each value attributed to its federal source and dated.
 * [LatLng](https://www.latlng.work/) - OSM-based geocoding, reverse geocoding, places, static maps, and tile APIs.
 * [LYRASENSE](https://lyrasense.com) - Agentic AI platform for satellite data analysis with a notebook environment and Google Earth Engine integration.
 * [MapAtlas](https://mapatlas.eu/) - A mapping REST API providing geocoding, directions, route optimization, matrix, isochrone, MVT vector tiles, map matching, and GeoEnrich services using OpenStreetMap and proprietary data.


### PR DESCRIPTION
Adds Knowground (https://www.knowground.com) to the SaaS section.

Disclosure: I work on knowground — submitting it because it's a genuine fit alongside the address/parcel public-data lookups already in this section (AssessorSearch, BC Property Check, SafeStreets, PixelGust).

What it is: a free, no-signup lookup of per-address US civic & environmental data — FEMA flood zone, ground elevation, NCES public schools, EPA hazard facilities, FCC broadband, and Census/ACS — every value attributed to its federal source and dated. One link, alphabetical placement, free/no login.