### PR TITLE
Add NMEA Checksum Calculator to SaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ with GNSS (global navigation satellite system).
 * [movebank-api](https://github.com/movebank/movebank-api-doc) - Platform for animal tracking data.
 * [MyCarTracks](https://mycartracks.com) - Mainly app-based GPS vehicle tracking and automatic mileage tracking with route history, geofencing, mileage reports, and fleet visibility.
 * [NetLoc8](https://netloc8.com) - IP geolocation API with city-level precision and SDKs for Next.js, React, and Go. Free tier included.
+* [NMEA Checksum Calculator](https://beomanro.com/tools/net/nmea-checksum/) - Browser-based NMEA 0183 and AIS sentence checksum validator and calculator with batch processing and XOR step visualization.
 * [NextGIS](http://nextgis.com/) - A cloud geospatial service that allows you to create web GIS right in the browser.
 * [OnCoord](https://www.oncoord.com) - Geocoding, reverse geocoding, location intelligence, and geospatial APIs for Latin America. Includes population, terrain, nightlight activity, and POI services.
 * [Open Notify](http://open-notify.org/Open-Notify-API/) - ISS location and number of people in space.


### PR DESCRIPTION
Adds [NMEA Checksum Calculator](https://beomanro.com/tools/net/nmea-checksum/) to the SaaS section (alphabetical position, after NetLoc8).

- Browser-based NMEA 0183 / AIS (AIVDM/AIVDO) sentence checksum validator and calculator
- Batch (multi-line) validation, XOR accumulation step visualization for debugging
- Free, no signup, runs entirely client-side
- Similar in spirit to the existing bng2latlong entry (single-purpose geo web utility)

Disclosure: I built this tool.