### PR TITLE
Add Maparz — free GDAL-powered online geospatial file converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,6 +1644,7 @@ for geospatial and tabular data.
 * [Kongsberg Geospatial's TerraLens SDK](https://www.kongsberggeospatial.com/products/terralens) - SDK designed for easy project integration and quick implementation in virtually any development environment. TerraLens provides real-time 2D and 3D mapping with powerful data visualization tools.
 * [landsat-espa-util](https://github.com/loicdtx/landsat-espa-util) - Library for querying and ordering Landsat Surface Reflectance data via ESPA.
 * [Magrit](https://github.com/riatelab/magrit) - Magrit is an online application for thematic mapping.
+* [Maparz](https://maparz.com/) - Free online geospatial file converter powered by GDAL. Converts between Shapefile, GeoJSON, KML/KMZ, GeoPackage, GPX, DXF, GML, FlatGeobuf and CSV — 81 conversion pairs, live map preview, no signup or installation required.
 * [MapShaper](http://mapshaper.org/) - Tools for editing Shapefile, GeoJSON, TopoJSON and CSV files.
 * [MapTiler Desktop](https://www.maptiler.com/desktop/) - Software for converting your data into fast zoomable maps. Load your image or geodata and get a tiled map.
 * [Mapus](https://github.com/alyssaxuu/mapus) - Mapus is a tool to explore and annotate collaboratively on a map.


### PR DESCRIPTION
## What is Maparz?

[Maparz](https://maparz.com/) is a free, open-access online geospatial file converter powered by GDAL — the same engine behind QGIS, ArcGIS and Google Earth Engine.

**Key features:**
- **81 conversion pairs** across 10 vector formats: Shapefile, GeoJSON, KML, KMZ, GeoPackage, GPX, DXF, GML, FlatGeobuf, CSV
- **Live map preview** — renders geometry on an interactive Leaflet map before and after conversion
- **No signup, no installation, no rate limits** — files are deleted immediately after conversion
- **GDAL-powered** — format-compliant conversions using ogr2ogr under the hood

**Why it fits Awesome-Geospatial:**
Maparz fills the same niche as MapShaper and ogr2ogr but as a browser-based tool accessible to users without GIS software installed. Useful for GIS practitioners who need a quick, reliable format conversion without opening QGIS or running a CLI command.

**Placement:** Added alphabetically in the `## Tools` section between Magrit and MapShaper.