### PR TITLE
Add League of Spin MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ with GNSS (global navigation satellite system).
 ## MCP Servers
 
 * [emem](https://github.com/Vortx-AI/emem) - Earth memory MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.
+* [League of Spin](https://leagueofspin.com/api/mcp) - Remote MCP server for finding 27,000+ outdoor ping-pong tables worldwide, built on OpenStreetMap data, with spot details and live playing conditions.
 * [Microsoft Planetary Computer Pro MCP Tools](https://marketplace.visualstudio.com/items?itemName=ms-planetarycomputer.mpc-pro-mcp-tools) - A Model Context Protocol (MCP) server that enables GitHub Copilot to interact with Microsoft Planetary Computer Pro.
 * [NetLoc8 MCP](https://github.com/netloc8/netloc8-mcp) - Model Context Protocol server giving AI assistants geolocation tools to lookup country, city, region, timezone, coordinates, and ASN.
 


### PR DESCRIPTION
Adds League of Spin (https://leagueofspin.com) to the MCP Servers section — a remote MCP server (streamable-http, `https://leagueofspin.com/api/mcp`) for finding outdoor ping-pong/table-tennis tables, 27,000+ spots worldwide built on OpenStreetMap data with live playing-condition details. Registered in the official MCP registry as `com.leagueofspin/spots`.