### PR TITLE
Add Honua SDK JS to Web Map Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
 * [Google Maps API Polyline String Decoder](https://github.com/mgd722/decode-google-maps-polyline) - Function that will convert encoded polyline strings (as returned by the Google Maps API) into a list of lat/lon pairs.
 * [gridviz](https://github.com/eurostat/gridviz) - A package for visualizing gridded data.
 * [HERE maps API](https://developer.here.com/develop/javascript-api) - Build web applications with feature-rich and customizable HERE maps.
+* [Honua SDK JS](https://github.com/honua-io/honua-sdk-js) - TypeScript geospatial client for ArcGIS/Esri GeoServices, OGC API, WFS, WMS/WMTS, STAC, OData, and GeoParquet with a MapLibre runtime and an ArcGIS migration codemod. [Example](https://honua-io.github.io/honua-sdk-js/guides/quickstart.html)
 * [jVectorMap](https://jvectormap.com/) - jVectorMap is a vector-based, cross-browser and cross-platform component for interactive geography-related data visualization on the web. It provides numerious features like smooth zooming and panning, fully-customizable styling, markers, labels and tooltips.
 * [L7](https://github.com/antvis/L7) - Large-scale WebGL-powered Geospatial Data Visualization By Ant Financial
 * [Leaflet](http://leafletjs.com/) - Open-Source JavaScript Library for Mobile-Friendly Interactive Maps.


### PR DESCRIPTION
Adds Honua SDK JS to Web Map Development.

Honua is an Apache-2.0 TypeScript client for ArcGIS/Esri GeoServices, OGC API, WFS, WMS/WMTS, STAC, OData, and GeoParquet. It includes a MapLibre runtime and an ArcGIS-to-MapLibre migration codemod.

The linked [quickstart](https://honua-io.github.io/honua-sdk-js/guides/quickstart.html) is published from the SDK repository and kept green by its browser smoke lane.

Validation:

- one Markdown entry in the existing Web Map Development format and alphabetical position
- repository and example links return HTTP 200
- upstream SDK CI and docs workflows are green on trunk

Tracks honua-io/honua-sdk-js#499.
