### PR TITLE
Add Planetary Atlas to 3D Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
 * [CityEngine](http://www.esri.com/software/cityengine/) - Transform 2D GIS Data into Smart 3D City Models
 * [Google Earth](http://earth.google.com/) - Bringing a earth view for global mapping
 * [Open3D](http://www.open3d.org/) - Open-source library that supports rapid development of software that deals with 3D data. The Open3D frontend exposes a set of carefully selected data structures and algorithms in both C++ and Python.
+* [Planetary Atlas](https://planetatlas.org) - Browser-based 3D globes of 14 worlds built from open NASA, USGS, ESA and JAXA imagery, with the IAU nomenclature and surface mission landing sites
 * [Skyline](http://www.skylineglobe.com/SkylineGlobe/corporate/Default.aspx?) - A glimpse into Skyline's cutting-edge 3D geospatial visualization products, and their potential to transform the way your organization makes decisions, shares information and manages its assets
 * [World Wind](http://worldwind.arc.nasa.gov/java/) -  Providing features for displaying with geographic data
 


### PR DESCRIPTION
Adds [Planetary Atlas](https://planetatlas.org) to **3D Application**, inserted alphabetically between Open3D and Skyline.

A browser-based 3D globe viewer for 14 worlds — four planets, seven moons, Ceres and two asteroids — built entirely from open agency imagery (NASA, USGS, ESA, JAXA, CNSA). 830 imagery layers, the full IAU nomenclature at 15,025 named features, and 69 surface mission landing sites, from global basemaps down to 26 cm/px over the Apollo 11 descent stage. CesiumJS, with solar illumination computed per body rather than from Earth's sub-solar point.

It sits in the same category as the existing Google Earth, ArcGIS Earth and World Wind entries — a 3D globe you fly around — applied to planetary surfaces instead of Earth. Free, no account, runs in the browser.