### PR TITLE
Add CARTO for Agents to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ with GNSS (global navigation satellite system).
 
 ## MCP Servers
 
+* [CARTO for Agents](https://docs.carto.com/carto-for-agents?utm_source=awesome-geospatial&utm_medium=listing&utm_campaign=mcp-marketplace-listings) - Official remote MCP server for CARTO, the Agentic GIS platform. Query governed warehouse data, run spatial analysis, create or edit maps and workflows, and render interactive maps in the conversation; every tool call runs inside your own data warehouse (BigQuery, Snowflake, Databricks, Redshift, or PostgreSQL).
 * [emem](https://github.com/Vortx-AI/emem) - Earth memory MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.
 * [League of Spin](https://leagueofspin.com/api/mcp) - Remote MCP server for finding 27,000+ outdoor ping-pong tables worldwide, built on OpenStreetMap data, with spot details and live playing conditions.
 * [Microsoft Planetary Computer Pro MCP Tools](https://marketplace.visualstudio.com/items?itemName=ms-planetarycomputer.mpc-pro-mcp-tools) - A Model Context Protocol (MCP) server that enables GitHub Copilot to interact with Microsoft Planetary Computer Pro.


### PR DESCRIPTION
Adds the official CARTO MCP server to the **MCP Servers** section, in alphabetical order.

CARTO is an enterprise geospatial platform that runs natively on your cloud data warehouse. The MCP server lets AI agents browse governed warehouse data, run spatial SQL and geospatial analysis, render interactive maps in the conversation, and create or edit CARTO maps and Workflows.

The MCP endpoint is org-specific (per region and account), so the entry links to the setup docs rather than to a single server URL, following the same pattern as other hosted servers already on the list.

Disclosure: I work at CARTO.
