### PR TITLE
Add AeroCartwright drone mapping calculators to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1639,6 +1639,7 @@ with GNSS (global navigation satellite system).
 ## Tools
 
 * [52North SOS](http://52north.org/communities/sensorweb/sos/) - A reference implementation of the [OGC Sensor Observation Service specification (version 2.0)]
+* [AeroCartwright Drone Mapping Calculators](https://aerocartwright.com/tools/) - Free browser-based ground sample distance (GSD) and ground control point (GCP) calculators for drone survey flight planning and accuracy; no signup.
 * [Bounding Box Tool](https://vibhorsingh.com/boundingbox) - Interactive tool for drawing bounding boxes on a map and exporting as WKT, GeoJSON, KML, Overpass API, OGC BBOX, STAC and more. Supports 3,900+ EPSG projections and Uber H3 grid tools.
 * [CODA](http://stcorp.github.io/coda/doc/html/index.html) - The Common Data Access toolbox (CODA) provides a set of tools for ingesting, processing, and analyzing remote sensing data.
 * [CoordinateMapper](https://coordinatemapper.com/) - Free browser-based tool for converting between lat/long, UTM, UK Grid References, Easting/Northing, MGRS, DMS and DDM. Includes map preview and CSV/KML/DXF export.


### PR DESCRIPTION
Adds two free, no-signup browser-based calculators to the **Tools** section, in alphabetical order:

- **GSD (ground sample distance) calculator** — sensor specs + target GSD → flight altitude, image footprint, coverage rate
- **GCP (ground control point) calculator** — survey area + accuracy target + terrain → recommended GCP/checkpoint count and placement

Both are static web tools (no login, no paywall), in the same spirit as existing entries like CoordinateMapper and Bounding Box Tool. Single hub link covers both. Happy to adjust the wording or split into two entries if you'd prefer.