### PR TITLE
Add bhoonidhi-mcp to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ with GNSS (global navigation satellite system).
 
 ## MCP Servers
 
+* [bhoonidhi-mcp](https://github.com/geovicco-dev/bhoonidhi-mcp) - Model Context Protocol server for ISRO's Bhoonidhi Earth-observation portal, over the bhoonidhi-downloader SDK. Lets an AI agent search the archive in natural language, resolve place names and satellite tokens, report each scene's availability, and (with a login) save queries, download open-access scenes, and stage scenes to the cart.
 * [CARTO for Agents](https://docs.carto.com/carto-for-agents?utm_source=awesome-geospatial&utm_medium=listing&utm_campaign=mcp-marketplace-listings) - Official remote MCP server for CARTO, the Agentic GIS platform. Query governed warehouse data, run spatial analysis, create or edit maps and workflows, and render interactive maps in the conversation; every tool call runs inside your own data warehouse (BigQuery, Snowflake, Databricks, Redshift, or PostgreSQL).
 * [emem](https://github.com/Vortx-AI/emem) - Earth memory MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.
 * [League of Spin](https://leagueofspin.com/api/mcp) - Remote MCP server for finding 27,000+ outdoor ping-pong tables worldwide, built on OpenStreetMap data, with spot details and live playing conditions.


### PR DESCRIPTION
Adds `bhoonidhi-mcp` to the **MCP Servers** section (inserted alphabetically).

[bhoonidhi-mcp](https://github.com/geovicco-dev/bhoonidhi-mcp) is an open-source (MIT) Model Context Protocol server for ISRO's Bhoonidhi Earth-observation portal. It's a thin adapter over the [bhoonidhi-downloader](https://github.com/geovicco-dev/bhoonidhi-downloader) SDK, letting an AI agent search the Indian EO archive in natural language, resolve place names to coordinates and casual satellite names to the portal's exact tokens, report each scene's live availability, and — once logged in — save queries, download open-access scenes, and stage the rest to the portal cart.

- Public repo, MIT licensed, tested, with a README and docs.
- Single-line addition, entry format matches the section, links verified live.