### PR TITLE
Add ShowMeOnMap (SaaS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ with GNSS (global navigation satellite system).
 * [RainViewer](https://www.rainviewer.com/api.html) - Free weather radar and satellite data API.
 * [REST countries](https://restcountries.com/) - Get country information via a RESTful API.
 * [SafeStreets](https://safestreets.streetsandcommons.com) - Free address-level walkability and pedestrian-safety analysis, scoring any neighborhood on a 15-minute-city framework using OpenStreetMap and public data.
+* [ShowMeOnMap](https://showmeonmap.com) - Natural-language questions to cited interactive maps; live hazard layers, embeds, MCP/WebMCP agent tools.
 * [Sunrise and sunset](https://sunrise-sunset.org) - Provides sunset and sunrise times for locations.
 * [TomTom](https://developer.tomtom.com/api-explorer-index/documentation/product-information/introduction) - Geocoding, routing, traffic, and more.
 * [USGS earthquake data](https://earthquake.usgs.gov/fdsnws/event/1/) - Search earthquake data by various parameters.


### PR DESCRIPTION
Adds [ShowMeOnMap](https://showmeonmap.com) to the **SaaS** section, in alphabetical position.

ShowMeOnMap turns natural-language questions ("active wildfires in BC", "elementary schools in Kerrisdale with their catchments") into interactive maps rendered from live, cited public data sources — live hazard layers (wildfire, earthquake, weather), embeddable maps, and MCP/WebMCP tools for AI agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)