### PR TITLE
Add Agent Skills section with geoai-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Long list of geospatial analysis tools. Geospatial analysis, or just spatial ana
   - [Google Earth Engine](#google-earth-engine)
   - [Deep Learning](#deep-learning)
   - [MCP Servers](#mcp-servers)
+  - [Agent Skills](#agent-skills)
   - [C](#c)
   - [C++](#c-1)
   - [C Sharp](#c-sharp)
@@ -544,6 +545,10 @@ with GNSS (global navigation satellite system).
 * [League of Spin](https://leagueofspin.com/api/mcp) - Remote MCP server for finding 27,000+ outdoor ping-pong tables worldwide, built on OpenStreetMap data, with spot details and live playing conditions.
 * [Microsoft Planetary Computer Pro MCP Tools](https://marketplace.visualstudio.com/items?itemName=ms-planetarycomputer.mpc-pro-mcp-tools) - A Model Context Protocol (MCP) server that enables GitHub Copilot to interact with Microsoft Planetary Computer Pro.
 * [NetLoc8 MCP](https://github.com/netloc8/netloc8-mcp) - Model Context Protocol server giving AI assistants geolocation tools to lookup country, city, region, timezone, coordinates, and ASN.
+
+## Agent Skills
+
+* [geoai-skills](https://github.com/muend/geoai-skills) - Vendor-neutral Agent Skills (SKILL.md) that make an AI coding agent check coordinate reference systems, spatial validation, comparability and uncertainty before a result becomes a claim. Works with Claude Code, Codex, Cursor and GitHub Copilot; ships a paired evaluation against a skills-disabled control arm, including the quality gate it fails.
 
 ## C
 


### PR DESCRIPTION
Adds a section for Agent Skills — SKILL.md collections that AI coding agents load, which are a distinct kind of resource from the MCP servers already listed: an MCP server exposes tools over a protocol, while a skill is instruction content the agent reads.

The entry is geoai-skills: 18 vendor-neutral skills covering the methodological layer between a request and a geospatial claim — CRS and unit handling, spatial leakage in ML validation, comparability preconditions for change detection, geometry validity, uncertainty reporting. MIT licensed, works with Claude Code, Codex, Cursor and GitHub Copilot, archived on Zenodo (10.5281/zenodo.22288662).

One note for the maintainer: the list already carries an agent skill under `## Python` — GeoSQL, described there as a "Claude/Codex skill". It may belong in this new section, but I have not moved another project's entry; that is your call.

https://github.com/muend/geoai-skills