### PR TITLE
Add PurRDF Geo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1509,6 +1509,7 @@ with GNSS (global navigation satellite system).
 * [proj](https://github.com/georust/rust-proj) - Rust bindings for Proj.
 * [Proj4rs](https://github.com/3liz/proj4rs) - Rust adaptation of Proj4
 * [Proj4wkt](https://github.com/3liz/proj4wkt-rs) - Parse WKT to Proj strings
+* [PurRDF Geo](https://crates.io/crates/purrdf-geo) - Pure-Rust GeoSPARQL 1.1 implementation using exact rational geometry for deterministic topological predicates, with WKT and GeoJSON support.
 * [Quadbin](https://github.com/atsyplenkov/qbin) - Hierarchical geospatial index tiling, similar to Quadkey.
 * [rasters.rs](https://github.com/AspecScire/rasters.rs) - Raster processing library and tools written in rust.
 * [rgeometry](https://github.com/rgeometry/rgeometry) - Computational Geometry library written in Rust.


### PR DESCRIPTION
Adds PurRDF Geo to the Rust section, placed alphabetically between `Proj4wkt`
and `Quadbin`.

Pure-Rust GeoSPARQL 1.1 (OGC 22-047r1): WKT and GeoJSON literals parsed into an
exact rational geometry model, with the Simple Features, Egenhofer and RCC8
relation families decided over an exact DE-9IM. No GEOS, no PROJ, and no
floating-point arithmetic — the single float boundary is the `xsd:double`
result literal.

It is a sibling crate of an RDF 1.2 toolkit rather than a standalone geometry
library, so its surface is the `geof:` function family and the Query Rewrite
relations reached from SPARQL.

MIT OR Apache-2.0, published on crates.io as `purrdf-geo` (1.1.0).

Disclosure: I am a PurRDF maintainer.