### PR TITLE
Add OSM Edit MCP to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ with GNSS (global navigation satellite system).
 * [League of Spin](https://leagueofspin.com/api/mcp) - Remote MCP server for finding 27,000+ outdoor ping-pong tables worldwide, built on OpenStreetMap data, with spot details and live playing conditions.
 * [Microsoft Planetary Computer Pro MCP Tools](https://marketplace.visualstudio.com/items?itemName=ms-planetarycomputer.mpc-pro-mcp-tools) - A Model Context Protocol (MCP) server that enables GitHub Copilot to interact with Microsoft Planetary Computer Pro.
 * [NetLoc8 MCP](https://github.com/netloc8/netloc8-mcp) - Model Context Protocol server giving AI assistants geolocation tools to lookup country, city, region, timezone, coordinates, and ASN.
+* [OSM Edit MCP](https://github.com/skywinder/osm-edit-mcp) - Python MCP server for inspecting OpenStreetMap data and previewing version-checked road-edit proposals from selected local GPX survey segments. Applying changes requires explicit user confirmation of the proposal digest. Alpha.
 
 ## C
 


### PR DESCRIPTION
Adds OSM Edit MCP to the existing MCP Servers section in alphabetical order. It is a Python server for inspecting OpenStreetMap data and reviewing road-edit proposals from selected GPX survey segments, with explicit confirmation before applying changes.

I maintain the project. The entry identifies its alpha status; version [0.2.1 is available on PyPI](https://pypi.org/project/osm-edit-mcp/0.2.1/) via `uvx osm-edit-mcp`.

Checked the project link, existing entries and PRs for duplicates, and `git diff --check`.
